### PR TITLE
Align published lifecycle with CI PTY support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,6 +225,9 @@ jobs:
       - name: Run lifecycle through released CLI, chart, and images
         env:
           DEVBOXES_VERSION: ${{ github.ref_name }}
+          # GitHub-hosted runners cannot retain an SSH PTY through Kind's port-forward.
+          # CI separately validates the workspace shell and tmux with a real TTY.
+          DEVBOXES_E2E_INTERACTIVE_SSH: "0"
         run: |
           DEVBOXES_VERSION="${DEVBOXES_VERSION#v}" scripts/published-e2e.sh
 


### PR DESCRIPTION
## Summary\n- keep the published release lifecycle on the real CLI, chart, images, pod, and SSH path\n- use the dedicated workspace real-TTY job for tmux terminal validation on GitHub-hosted runners\n\n## Validation\n- actionlint (when available)\n- shared lifecycle passed locally with interactive SSH enabled\n- v0.2.0 PR CI passed all nine jobs