### PR TITLE
Restore interactive SSH PTY allocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,8 +159,4 @@ jobs:
           go install sigs.k8s.io/kind@v0.31.0
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       - name: Run full lifecycle E2E
-        env:
-          # GitHub-hosted runners cannot retain an SSH PTY through Kind's port-forward.
-          # The workspace image job above exercises the same shell with a real TTY.
-          DEVBOXES_E2E_INTERACTIVE_SSH: "0"
         run: scripts/kind-e2e.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,9 +225,6 @@ jobs:
       - name: Run lifecycle through released CLI, chart, and images
         env:
           DEVBOXES_VERSION: ${{ github.ref_name }}
-          # GitHub-hosted runners cannot retain an SSH PTY through Kind's port-forward.
-          # CI separately validates the workspace shell and tmux with a real TTY.
-          DEVBOXES_E2E_INTERACTIVE_SSH: "0"
         run: |
           DEVBOXES_VERSION="${DEVBOXES_VERSION#v}" scripts/published-e2e.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Devboxes are documented here. The project follows [Keep a
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-07-13
+
+### Fixed
+
+- Restored interactive SSH PTY allocation on capability-enforcing Kubernetes runtimes by granting workspace OpenSSH only `AUDIT_WRITE` in addition to the existing minimal capabilities.
+- Re-enabled the real SSH PTY lifecycle in pull-request and published-release cluster gates.
+
 ## [0.2.0] - 2026-07-13
 
 ### Added
@@ -60,7 +67,8 @@ All notable changes to Devboxes are documented here. The project follows [Keep a
 - Portable Helm chart with values schema, namespace-scoped RBAC, configurable storage, ingress, LoadBalancer or NodePort SSH, ServiceMonitor, and disruption budget.
 - macOS and Linux CLI releases, SHA-256 verification installer, GHCR images, OCI chart publishing, image provenance attestations, and clean Kind install CI.
 
-[Unreleased]: https://github.com/vicotrbb/devboxes/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/vicotrbb/devboxes/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/vicotrbb/devboxes/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/vicotrbb/devboxes/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/vicotrbb/devboxes/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/vicotrbb/devboxes/compare/v0.1.0...v0.1.1

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Devboxes is currently a single-operator system: one shared token controls every 
 - An SSH public key.
 - An ingress controller and TLS certificate only if you expose the dashboard through ingress. Port-forwarding works without either.
 
-The workspace container intentionally supports passwordless `sudo` for the trusted development user. Its pod drops all capabilities and adds back a small set needed by `sudo`, but it is not compatible with the Kubernetes `restricted` Pod Security profile. Use the `baseline` profile or an equivalent policy in the Devboxes namespace.
+The workspace container intentionally supports passwordless `sudo` for the trusted development user. Its pod drops all capabilities and adds back a small set needed by `sudo` and OpenSSH PTY auditing, but it is not compatible with the Kubernetes `restricted` Pod Security profile. Use the `baseline` profile or an equivalent policy in the Devboxes namespace.
 
 ## Install
 
@@ -84,7 +84,7 @@ kubectl -n devboxes create secret generic devboxes-workspace \
   --from-file=SSH_AUTHORIZED_KEYS="$HOME/.ssh/id_ed25519.pub"
 
 helm install devboxes oci://ghcr.io/vicotrbb/charts/devboxes \
-  --version 0.2.0 \
+  --version 0.2.1 \
   --namespace devboxes
 ```
 

--- a/charts/devboxes/Chart.yaml
+++ b/charts/devboxes/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: devboxes
 description: Self-hosted, ephemeral development environments on Kubernetes
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.2.1
+appVersion: "0.2.1"
 kubeVersion: ">=1.29.0-0"
 home: https://github.com/vicotrbb/devboxes
 icon: https://raw.githubusercontent.com/vicotrbb/devboxes/main/docs/assets/devboxes-mark.svg

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "devbox-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devbox-cli"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.96"
 description = "Terminal client for self-hosted Kubernetes development environments"

--- a/controller/pyproject.toml
+++ b/controller/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "devboxes-controller"
-version = "0.2.0"
+version = "0.2.1"
 description = "Controller and dashboard for self-hosted Kubernetes development environments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/controller/src/devboxes_controller/__init__.py
+++ b/controller/src/devboxes_controller/__init__.py
@@ -1,3 +1,3 @@
 """Devboxes controller package."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/controller/src/devboxes_controller/resources.py
+++ b/controller/src/devboxes_controller/resources.py
@@ -141,10 +141,12 @@ def build_deployment(
                 },
                 "securityContext": {
                     # The trusted dev user needs setuid sudo inside this disposable container.
+                    # OpenSSH also writes a login audit record while allocating a PTY.
                     "allowPrivilegeEscalation": True,
                     "capabilities": {
                         "drop": ["ALL"],
                         "add": [
+                            "AUDIT_WRITE",
                             "CHOWN",
                             "DAC_OVERRIDE",
                             "FOWNER",

--- a/controller/src/devboxes_controller/templates/cli_authorize.html
+++ b/controller/src/devboxes_controller/templates/cli_authorize.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="color-scheme" content="light">
     <title>Authorize Devbox CLI · Devboxes</title>
-    <link rel="icon" href="/static/favicon.svg?v=0.2.0" type="image/svg+xml">
-    <link rel="stylesheet" href="/static/styles.css?v=0.2.0">
+    <link rel="icon" href="/static/favicon.svg?v=0.2.1" type="image/svg+xml">
+    <link rel="stylesheet" href="/static/styles.css?v=0.2.1">
   </head>
   <body class="login-page">
     <main class="authorization-shell" aria-labelledby="authorization-title">

--- a/controller/src/devboxes_controller/templates/docs.html
+++ b/controller/src/devboxes_controller/templates/docs.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="color-scheme" content="light">
     <title>Documentation · Devboxes</title>
-    <link rel="icon" href="/static/favicon.svg?v=0.2.0" type="image/svg+xml">
-    <link rel="stylesheet" href="/static/styles.css?v=0.2.0">
-    <script src="/static/docs.js?v=0.2.0" defer></script>
+    <link rel="icon" href="/static/favicon.svg?v=0.2.1" type="image/svg+xml">
+    <link rel="stylesheet" href="/static/styles.css?v=0.2.1">
+    <script src="/static/docs.js?v=0.2.1" defer></script>
   </head>
   <body class="docs-page">
     <a class="skip-link" href="#main-content">Skip to documentation</a>

--- a/controller/src/devboxes_controller/templates/index.html
+++ b/controller/src/devboxes_controller/templates/index.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="color-scheme" content="light">
     <title>Devboxes</title>
-    <link rel="icon" href="/static/favicon.svg?v=0.2.0" type="image/svg+xml">
-    <link rel="stylesheet" href="/static/styles.css?v=0.2.0">
-    <script src="/static/app.js?v=0.2.0" defer></script>
+    <link rel="icon" href="/static/favicon.svg?v=0.2.1" type="image/svg+xml">
+    <link rel="stylesheet" href="/static/styles.css?v=0.2.1">
+    <script src="/static/app.js?v=0.2.1" defer></script>
   </head>
   <body>
     <a class="skip-link" href="#main-content">Skip to content</a>

--- a/controller/src/devboxes_controller/templates/login.html
+++ b/controller/src/devboxes_controller/templates/login.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="color-scheme" content="light">
     <title>Sign in · Devboxes</title>
-    <link rel="icon" href="/static/favicon.svg?v=0.2.0" type="image/svg+xml">
-    <link rel="stylesheet" href="/static/styles.css?v=0.2.0">
+    <link rel="icon" href="/static/favicon.svg?v=0.2.1" type="image/svg+xml">
+    <link rel="stylesheet" href="/static/styles.css?v=0.2.1">
   </head>
   <body class="login-page">
     <main class="login-shell">

--- a/controller/tests/test_app.py
+++ b/controller/tests/test_app.py
@@ -79,7 +79,7 @@ def test_browser_login_and_dashboard_session() -> None:
         assert dashboard.headers["x-content-type-options"] == "nosniff"
         assert "Kubernetes connected" in dashboard.text
         assert "cluster default storage" in dashboard.text
-        styles = client.get("/static/styles.css?v=0.2.0")
+        styles = client.get("/static/styles.css?v=0.2.1")
         assert "[hidden]" in styles.text
         assert "display: none !important" in styles.text
         payload = client.get("/api/v1/devboxes").json()

--- a/controller/tests/test_resources.py
+++ b/controller/tests/test_resources.py
@@ -39,6 +39,7 @@ def test_deployment_is_hardened_and_ready_for_tmux_workspace() -> None:
     assert container["resources"]["limits"] == {"memory": "8Gi"}
     assert "cpu" not in container["resources"]["limits"]
     assert container["securityContext"]["allowPrivilegeEscalation"] is True
+    assert "AUDIT_WRITE" in container["securityContext"]["capabilities"]["add"]
     assert "SYS_CHROOT" in container["securityContext"]["capabilities"]["add"]
     assert "SYS_ADMIN" not in container["securityContext"]["capabilities"]["add"]
     secret_volume = next(

--- a/controller/uv.lock
+++ b/controller/uv.lock
@@ -382,7 +382,7 @@ wheels = [
 
 [[package]]
 name = "devboxes-controller"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,7 +51,7 @@ The workspace entrypoint refuses to start without `SSH_AUTHORIZED_KEYS`. It prep
 - Workspace Secrets are mounted read-only with mode `0440`, scoped to the workspace group, and are not embedded in either image.
 - The controller runs as a non-root user with a read-only root filesystem and all Linux capabilities dropped.
 - The workspace runs as root during initialization, then exposes only the unprivileged `dev` SSH user. Password login and root login are disabled.
-- The trusted `dev` user has passwordless `sudo`. The pod adds only `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETGID`, `SETUID`, and `SYS_CHROOT`; `SYS_ADMIN` and privileged mode are not used.
+- The trusted `dev` user has passwordless `sudo`. The pod adds only `AUDIT_WRITE`, `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETGID`, `SETUID`, and `SYS_CHROOT`; `AUDIT_WRITE` lets OpenSSH allocate audited PTYs, while `SYS_ADMIN` and privileged mode are not used.
 - SSH host checking uses a stable alias scoped to both the Devboxes installation and box name, preventing collisions across installations.
 - CLI callbacks accept only exact HTTP loopback URIs with numeric loopback hosts, explicit non-privileged ports, and `/callback`; login return targets accept only the internal authorization route.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,9 +3,9 @@
 Use a values file for durable installations:
 
 ```bash
-helm show values oci://ghcr.io/vicotrbb/charts/devboxes --version 0.2.0 > values.yaml
+helm show values oci://ghcr.io/vicotrbb/charts/devboxes --version 0.2.1 > values.yaml
 helm upgrade --install devboxes oci://ghcr.io/vicotrbb/charts/devboxes \
-  --version 0.2.0 \
+  --version 0.2.1 \
   --namespace devboxes \
   --create-namespace \
   --values values.yaml

--- a/docs/golden-path.md
+++ b/docs/golden-path.md
@@ -38,7 +38,7 @@ kubectl create namespace devboxes
 # Create devboxes-auth and devboxes-workspace here, as described below.
 
 helm upgrade --install devboxes oci://ghcr.io/vicotrbb/charts/devboxes \
-  --version 0.2.0 \
+  --version 0.2.1 \
   --namespace devboxes \
   --values values.yaml
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "devboxes-repository-tooling",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "devboxes-repository-tooling",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "devDependencies": {
         "@eslint/js": "10.0.1",
         "eslint": "10.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devboxes-repository-tooling",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "description": "JavaScript and documentation quality gates for Devboxes",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@ set -eu
 
 release="${DEVBOXES_RELEASE:-devboxes}"
 namespace="${DEVBOXES_NAMESPACE:-devboxes}"
-version="${DEVBOXES_VERSION:-0.2.0}"
+version="${DEVBOXES_VERSION:-0.2.1}"
 repository="${DEVBOXES_CHART_REPOSITORY:-oci://ghcr.io/vicotrbb/charts/devboxes}"
 chart_source="${DEVBOXES_CHART_SOURCE:-auto}"
 controller_secret="${DEVBOXES_CONTROLLER_SECRET:-devboxes-auth}"


### PR DESCRIPTION
## Summary

- add the narrowly scoped `AUDIT_WRITE` capability required by OpenSSH when allocating an interactive PTY
- re-enable real SSH PTY lifecycle coverage in clean-cluster CI and published-release verification
- prepare the immutable v0.2.1 patch release and document the capability boundary

## Validation

- `scripts/check-version.sh`
- `make lint`
- `make test`
- `make helm`
- `scripts/kind-e2e.sh` with interactive SSH enabled, including SSH, PTY allocation, stop, retained PVC reuse, SSH host identity continuity, and purge
