### PR TITLE
feat: add privacy-bounded Devbox Insights

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,8 @@ jobs:
         run: |
           go install github.com/zricethezav/gitleaks/v8@v8.30.1
           "$(go env GOPATH)/bin/gitleaks" detect --source . --no-git --redact --no-banner
-      - name: Helm lint
-        run: helm lint charts/devboxes --strict
+      - name: Helm Insights contracts
+        run: scripts/test-helm-insights.sh
       - name: Render LoadBalancer installation
         run: helm template devboxes charts/devboxes --namespace devboxes > /tmp/devboxes.yaml
       - name: Validate Kubernetes resources
@@ -158,5 +158,9 @@ jobs:
         run: |
           go install sigs.k8s.io/kind@v0.31.0
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+      - name: Build CLI for end-to-end verification
+        run: cargo build --manifest-path cli/Cargo.toml --locked
       - name: Run full lifecycle E2E
         run: scripts/kind-e2e.sh
+        env:
+          DEVBOXES_E2E_CLI: cli/target/debug/devbox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to Devboxes are documented here. The project follows [Keep a
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-14
+
+### Added
+
+- Added opt-in Devboxes Insights with local Codex and Claude telemetry ingestion, aggregate Git activity, durable workspace outboxes, and a persistent SQLite history store.
+- Added an authenticated, responsive Insights dashboard plus CLI summary, collector status, recent activity, CSV/JSON export, and explicit purge workflows.
+- Added Helm configuration, schema validation, retained central storage, scoped per-workspace ingest Secrets, workspace sidecars, backups, retention, and operational documentation for Insights.
+
+### Changed
+
+- Assigned every workspace a stable Insights instance identifier while leaving active legacy workspaces running and reporting that a normal restart is required to enable collection.
+- Expanded the Kind and release gates to prove provider-shaped ingestion, replay deduplication, Git baselines, controller and workspace restarts, retained history, backups, SSH, and explicit purge behavior.
+
+### Fixed
+
+- Made the Insights agent create its private outbox path before privilege drop, bind its loopback receiver before background work begins, and retry recoverable startup failures.
+- Preserved integer token totals across the SQLite API boundary and removed narrow-screen activity-list overflow from the dashboard.
+
+### Security
+
+- Added independent workspace and controller allowlists that reject prompts, responses, logs, commands, paths, Git identities, commit messages, and provider identity attributes before persistence.
+- Added scoped HMAC ingest credentials with write-only routes and kept controller and master access tokens out of workspace Deployments.
+
 ## [0.2.1] - 2026-07-13
 
 ### Fixed
@@ -67,7 +90,8 @@ All notable changes to Devboxes are documented here. The project follows [Keep a
 - Portable Helm chart with values schema, namespace-scoped RBAC, configurable storage, ingress, LoadBalancer or NodePort SSH, ServiceMonitor, and disruption budget.
 - macOS and Linux CLI releases, SHA-256 verification installer, GHCR images, OCI chart publishing, image provenance attestations, and clean Kind install CI.
 
-[Unreleased]: https://github.com/vicotrbb/devboxes/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/vicotrbb/devboxes/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/vicotrbb/devboxes/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/vicotrbb/devboxes/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/vicotrbb/devboxes/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/vicotrbb/devboxes/compare/v0.1.1...v0.1.2

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ bootstrap:
 lint:
 	npm run lint
 	cd controller && uv run ruff format --check . && uv run ruff check . && uv run mypy
+	cd controller && uv run ruff format --check ../workspace/insights_agent.py && uv run ruff check ../workspace/insights_agent.py
 	cd cli && cargo fmt --check && cargo clippy --all-targets --all-features --locked -- -D warnings
 	shellcheck scripts/*.sh workspace/*.sh workspace/devbox-shell workspace/tests/*.sh
 	workspace/tests/test-devbox-shell.sh
@@ -18,8 +19,7 @@ test:
 	cd cli && cargo test --all-features --locked
 
 helm:
-	helm lint charts/devboxes --strict
-	helm template devboxes charts/devboxes --namespace devboxes >/dev/null
+	scripts/test-helm-insights.sh
 	helm template devboxes charts/devboxes --namespace devboxes --set workspace.sshService.type=NodePort --set workspace.sshService.host=192.0.2.10 >/dev/null
 
 images:

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Each workspace includes Rust, Node.js, Python, `uv`, GitHub CLI, Codex CLI, Clau
 
 ## What ships
 
-- A Rust `devbox` CLI for create, list, inspect, SSH, start, stop, and delete workflows.
-- A FastAPI controller with an authenticated API, accessible browser workbench, documentation, metrics, health checks, and TTL cleanup.
+- A Rust `devbox` CLI for create, list, inspect, SSH, start, stop, delete, and opt-in Insights workflows.
+- A FastAPI controller with an authenticated API, accessible browser workbench, Insights dashboard, documentation, metrics, health checks, and TTL cleanup.
 - A versioned Helm chart with values schema validation and namespace-scoped RBAC.
 - Multi-architecture controller and workspace images for `linux/amd64` and `linux/arm64`.
 - Persistent SSH host identity, shell state, tool installs, account state, and source under `/home/dev`.
@@ -84,7 +84,7 @@ kubectl -n devboxes create secret generic devboxes-workspace \
   --from-file=SSH_AUTHORIZED_KEYS="$HOME/.ssh/id_ed25519.pub"
 
 helm install devboxes oci://ghcr.io/vicotrbb/charts/devboxes \
-  --version 0.2.1 \
+  --version 0.3.0 \
   --namespace devboxes
 ```
 
@@ -131,6 +131,31 @@ For clusters without a load balancer, let Kubernetes allocate a distinct NodePor
 ```
 
 See [configuration](docs/configuration.md) for every supported value and platform examples.
+
+### Enable Insights
+
+Insights is disabled by default. Enable it to collect privacy-bounded local AI metrics and aggregate Git activity into a persistent controller database:
+
+```yaml
+insights:
+  enabled: true
+  storage:
+    storageClass: fast-rwo
+    size: 2Gi
+    retainOnDelete: true
+```
+
+New and normally restarted workspaces receive a loopback-only collector sidecar. The collector uses a durable outbox on the workspace PVC and a scoped write-only credential. It never collects prompts, responses, commands, paths, file contents, Git authors, commit messages, or provider identities.
+
+Open `/insights` or query the same data through the CLI:
+
+```bash
+devbox metrics --since 7d
+devbox metrics status
+devbox metrics activity --box atlas
+```
+
+Insights is personal operational visibility, not billing, compliance, employee monitoring, or a productivity score. Read [Insights](docs/insights.md) before enabling it for metric semantics, trust boundaries, storage, backup, retention, and purge behavior.
 
 ## Install and use the CLI
 
@@ -221,11 +246,12 @@ devbox CLI / browser
           ▼
 Devboxes controller ─── Kubernetes API
           │                  │
+          │                  ├─ Secret (scoped Insights ingest credential)
           │                  ├─ Deployment (disposable compute)
           │                  ├─ Service (LoadBalancer or NodePort SSH)
           │                  └─ PVC (persistent /home/dev)
-          ▼
-  TTL cleanup and lifecycle state
+          ├─ TTL cleanup and lifecycle state
+          └─ Insights SQLite PVC (optional central history)
 ```
 
 The controller watches only its release namespace and receives namespace-scoped RBAC. Workspace pods do not receive Kubernetes service-account tokens. See [architecture](docs/architecture.md) for resource ownership, persistence, readiness, and threat boundaries.
@@ -248,13 +274,14 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md) before proposing a change. Security repo
 
 - [Golden path](docs/golden-path.md) for a performance-oriented installation and daily workflow.
 - [CLI reference](docs/cli.md) and [API reference](docs/api.md) for client contracts.
+- [Insights](docs/insights.md) for telemetry semantics, privacy, storage, backup, and purge.
 - [Configuration](docs/configuration.md) and [credentials](docs/credentials.md) for installation details.
 - [Operations](docs/operations.md) and [troubleshooting](docs/troubleshooting.md) for production ownership.
 - [Architecture](docs/architecture.md) and [development](docs/development.md) for maintainers.
 
 ## Project status
 
-Devboxes is at `v0.1`: useful and installable, with an intentionally narrow trust model. Compatibility follows semantic versioning after `v1.0`; before then, minor releases may include documented configuration or API changes. PVC data is never automatically deleted, including at TTL expiry.
+Devboxes is at `v0.3`: useful and installable, with an intentionally narrow trust model. Compatibility follows semantic versioning after `v1.0`; before then, minor releases may include documented configuration or API changes. PVC data is never automatically deleted, including at TTL expiry.
 
 ## License
 

--- a/charts/devboxes/Chart.yaml
+++ b/charts/devboxes/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: devboxes
 description: Self-hosted, ephemeral development environments on Kubernetes
 type: application
-version: 0.2.1
-appVersion: "0.2.1"
+version: 0.3.0
+appVersion: "0.3.0"
 kubeVersion: ">=1.29.0-0"
 home: https://github.com/vicotrbb/devboxes
 icon: https://raw.githubusercontent.com/vicotrbb/devboxes/main/docs/assets/devboxes-mark.svg
@@ -16,7 +16,9 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/category: integration-delivery
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Honor DEVBOX_TOKEN during non-interactive CLI login
-    - kind: fixed
-      description: Trust operating-system certificate roots in the CLI
+    - kind: added
+      description: Add privacy-bounded Devboxes Insights for AI metrics and aggregate Git activity
+    - kind: added
+      description: Add dashboard and CLI summary, status, activity, export, and purge workflows
+    - kind: security
+      description: Add dual allowlists and scoped per-workspace ingest credentials

--- a/charts/devboxes/templates/_helpers.tpl
+++ b/charts/devboxes/templates/_helpers.tpl
@@ -53,3 +53,7 @@ app.kubernetes.io/component: controller
 {{- define "devboxes.workspaceImage" -}}
 {{- printf "%s:%s" .Values.workspace.image.repository (default .Chart.AppVersion .Values.workspace.image.tag) }}
 {{- end }}
+
+{{- define "devboxes.insightsClaimName" -}}
+{{- default (printf "%s-insights" (include "devboxes.fullname" .)) .Values.insights.storage.existingClaim }}
+{{- end }}

--- a/charts/devboxes/templates/deployment.yaml
+++ b/charts/devboxes/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.insights.enabled (ne (int .Values.controller.replicaCount) 1) }}
+{{- fail "controller.replicaCount must be exactly 1 when insights.enabled=true" }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -9,7 +12,11 @@ metadata:
 spec:
   replicas: {{ .Values.controller.replicaCount }}
   strategy:
+    {{- if .Values.insights.enabled }}
+    type: Recreate
+    {{- else }}
     type: RollingUpdate
+    {{- end }}
   selector:
     matchLabels:
       {{- include "devboxes.selectorLabels" . | nindent 6 }}
@@ -92,6 +99,37 @@ spec:
             {{- end }}
             - name: DEVBOXES_LOG_LEVEL
               value: {{ .Values.controller.logLevel | quote }}
+            - name: DEVBOXES_INSIGHTS_ENABLED
+              value: {{ .Values.insights.enabled | quote }}
+            {{- if .Values.insights.enabled }}
+            - name: DEVBOXES_INSIGHTS_DB_PATH
+              value: /var/lib/devboxes/insights.db
+            - name: DEVBOXES_INSIGHTS_DATABASE_WARNING_BYTES
+              value: {{ int .Values.insights.storage.warningBytes | quote }}
+            - name: DEVBOXES_INSIGHTS_CONTROLLER_URL
+              value: {{ printf "http://%s:%v" (include "devboxes.fullname" .) .Values.service.port | quote }}
+            - name: DEVBOXES_INSIGHTS_RETENTION_RAW_DAYS
+              value: {{ int .Values.insights.retention.rawDays | quote }}
+            - name: DEVBOXES_INSIGHTS_RETENTION_HOURLY_DAYS
+              value: {{ int .Values.insights.retention.hourlyDays | quote }}
+            - name: DEVBOXES_INSIGHTS_RETENTION_DAILY_DAYS
+              value: {{ int .Values.insights.retention.dailyDays | quote }}
+            - name: DEVBOXES_INSIGHTS_AGENT_SCAN_INTERVAL_SECONDS
+              value: {{ int .Values.insights.agent.scanIntervalSeconds | quote }}
+            - name: DEVBOXES_INSIGHTS_AGENT_REPOSITORY_DEPTH
+              value: {{ int .Values.insights.agent.repositoryDepth | quote }}
+            - name: DEVBOXES_INSIGHTS_AGENT_MAX_QUEUE_BYTES
+              value: {{ int .Values.insights.agent.maxQueueBytes | quote }}
+            - name: DEVBOXES_INSIGHTS_AGENT_MAX_QUEUE_AGE_SECONDS
+              value: {{ int .Values.insights.agent.maxQueueAgeSeconds | quote }}
+            {{- if .Values.insights.signingKeyKey }}
+            - name: DEVBOXES_INSIGHTS_SIGNING_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.controller.existingSecret }}
+                  key: {{ .Values.insights.signingKeyKey }}
+            {{- end }}
+            {{- end }}
             - name: DEVBOXES_WORKSPACE_IMAGE
               value: {{ include "devboxes.workspaceImage" . | quote }}
             - name: DEVBOXES_WORKSPACE_SECRET_NAME
@@ -137,9 +175,18 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            {{- if .Values.insights.enabled }}
+            - name: insights
+              mountPath: /var/lib/devboxes
+            {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- if .Values.insights.enabled }}
+        - name: insights
+          persistentVolumeClaim:
+            claimName: {{ include "devboxes.insightsClaimName" . }}
+        {{- end }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/devboxes/templates/insights-pvc.yaml
+++ b/charts/devboxes/templates/insights-pvc.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.insights.enabled (not .Values.insights.storage.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "devboxes.insightsClaimName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "devboxes.labels" . | nindent 4 }}
+    app.kubernetes.io/component: insights
+  {{- if .Values.insights.storage.retainOnDelete }}
+  annotations:
+    helm.sh/resource-policy: keep
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.insights.storage.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.insights.storage.size }}
+  {{- with .Values.insights.storage.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/devboxes/templates/rbac.yaml
+++ b/charts/devboxes/templates/rbac.yaml
@@ -21,6 +21,9 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["create", "delete", "get", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "delete", "get", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/devboxes/values.schema.json
+++ b/charts/devboxes/values.schema.json
@@ -76,6 +76,49 @@
         }
       }
     },
+    "insights": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "signingKeyKey", "storage", "retention", "agent"],
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "signingKeyKey": {"type": "string"},
+        "storage": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["existingClaim", "storageClass", "size", "warningBytes", "accessMode", "retainOnDelete"],
+          "properties": {
+            "existingClaim": {"type": "string"},
+            "storageClass": {"type": "string"},
+            "size": {"type": "string", "pattern": "^[1-9][0-9]*(?:Mi|Gi|Ti)$"},
+            "warningBytes": {"type": "integer", "minimum": 1048576, "maximum": 1099511627776},
+            "accessMode": {"type": "string", "enum": ["ReadWriteOnce", "ReadWriteOncePod"]},
+            "retainOnDelete": {"type": "boolean"}
+          }
+        },
+        "retention": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["rawDays", "hourlyDays", "dailyDays"],
+          "properties": {
+            "rawDays": {"type": "integer", "minimum": 1, "maximum": 365},
+            "hourlyDays": {"type": "integer", "minimum": 1, "maximum": 730},
+            "dailyDays": {"type": "integer", "minimum": 1, "maximum": 3650}
+          }
+        },
+        "agent": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["scanIntervalSeconds", "repositoryDepth", "maxQueueBytes", "maxQueueAgeSeconds"],
+          "properties": {
+            "scanIntervalSeconds": {"type": "integer", "minimum": 15, "maximum": 3600},
+            "repositoryDepth": {"type": "integer", "minimum": 1, "maximum": 12},
+            "maxQueueBytes": {"type": "integer", "minimum": 1048576, "maximum": 2147483648},
+            "maxQueueAgeSeconds": {"type": "integer", "minimum": 60, "maximum": 31536000}
+          }
+        }
+      }
+    },
     "service": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/devboxes/values.yaml
+++ b/charts/devboxes/values.yaml
@@ -57,6 +57,28 @@ workspace:
     externalTrafficPolicy: Cluster
     loadBalancerSourceRanges: []
 
+insights:
+  enabled: false
+  # Optional key in controller.existingSecret. Empty derives a dedicated,
+  # domain-separated ingest key without exposing the master or CLI key.
+  signingKeyKey: ""
+  storage:
+    existingClaim: ""
+    storageClass: ""
+    size: 2Gi
+    warningBytes: 1717986918
+    accessMode: ReadWriteOnce
+    retainOnDelete: true
+  retention:
+    rawDays: 30
+    hourlyDays: 90
+    dailyDays: 365
+  agent:
+    scanIntervalSeconds: 60
+    repositoryDepth: 4
+    maxQueueBytes: 134217728
+    maxQueueAgeSeconds: 604800
+
 service:
   type: ClusterIP
   port: 8000

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "devbox-cli"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devbox-cli"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.96"
 description = "Terminal client for self-hosted Kubernetes development environments"

--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -7,7 +7,9 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 
 use crate::models::{
-    CliTokenRequest, CliTokenResponse, CreateDevbox, DeleteResult, Devbox, DevboxList, WhoAmI,
+    CliTokenRequest, CliTokenResponse, CreateDevbox, DeleteResult, Devbox, DevboxList,
+    InsightsActivityData, InsightsEnvelope, InsightsPurgeResult, InsightsStatusData,
+    InsightsSummary, WhoAmI,
 };
 
 pub struct ApiClient {
@@ -100,6 +102,62 @@ impl ApiClient {
         .await
     }
 
+    pub async fn insights_summary(
+        &self,
+        query: &[(String, String)],
+    ) -> Result<InsightsEnvelope<InsightsSummary>> {
+        self.request_query(Method::GET, "/api/v1/insights/summary", query)
+            .await
+    }
+
+    pub async fn insights_status(
+        &self,
+        query: &[(String, String)],
+    ) -> Result<InsightsEnvelope<InsightsStatusData>> {
+        self.request_query(Method::GET, "/api/v1/insights/capabilities", query)
+            .await
+    }
+
+    pub async fn insights_activity(
+        &self,
+        query: &[(String, String)],
+    ) -> Result<InsightsEnvelope<InsightsActivityData>> {
+        self.request_query(Method::GET, "/api/v1/insights/activity", query)
+            .await
+    }
+
+    pub async fn insights_export(&self, query: &[(String, String)]) -> Result<String> {
+        let response = self
+            .http
+            .get(self.url("/api/v1/insights/export", query)?)
+            .bearer_auth(&self.token)
+            .header("Accept", "application/json, text/csv")
+            .send()
+            .await
+            .context("failed to reach Devboxes API")?;
+        let status = response.status();
+        if !status.is_success() {
+            let payload = response.json::<Value>().await.unwrap_or(Value::Null);
+            bail!(
+                "Devboxes API returned {status}: {}",
+                api_error_detail(&payload)
+            );
+        }
+        response
+            .text()
+            .await
+            .context("Devboxes API returned an invalid export")
+    }
+
+    pub async fn purge_insights(&self, name: &str) -> Result<InsightsPurgeResult> {
+        self.request_query(
+            Method::DELETE,
+            "/api/v1/insights",
+            &[("box".to_owned(), name.to_owned())],
+        )
+        .await
+    }
+
     async fn request<B, R>(&self, method: Method, path: &str, body: Option<&B>) -> Result<R>
     where
         B: Serialize + Sync + ?Sized,
@@ -107,7 +165,7 @@ impl ApiClient {
     {
         let mut request = self
             .http
-            .request(method, format!("{}{}", self.base_url, path))
+            .request(method, self.url(path, &[])?)
             .bearer_auth(&self.token)
             .header("Accept", "application/json");
         if let Some(body) = body {
@@ -118,6 +176,36 @@ impl ApiClient {
             .await
             .context("failed to reach Devboxes API")?;
         decode_response(response).await
+    }
+
+    async fn request_query<R>(
+        &self,
+        method: Method,
+        path: &str,
+        query: &[(String, String)],
+    ) -> Result<R>
+    where
+        R: DeserializeOwned,
+    {
+        let response = self
+            .http
+            .request(method, self.url(path, query)?)
+            .bearer_auth(&self.token)
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .context("failed to reach Devboxes API")?;
+        decode_response(response).await
+    }
+
+    fn url(&self, path: &str, query: &[(String, String)]) -> Result<reqwest::Url> {
+        let mut url = reqwest::Url::parse(&format!("{}{}", self.base_url, path))
+            .context("failed to build Devboxes API URL")?;
+        if !query.is_empty() {
+            url.query_pairs_mut()
+                .extend_pairs(query.iter().map(|(key, value)| (key, value)));
+        }
+        Ok(url)
     }
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,13 +9,16 @@ use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use chrono::Utc;
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use tokio::process::Command;
 use tokio::time::{Instant, sleep};
 
 use client::ApiClient;
 use config::StoredConfig;
-use models::{CreateDevbox, Devbox, Preset};
+use models::{
+    CollectorStatus, CreateDevbox, Devbox, InsightsActivity, InsightsActivityData,
+    InsightsEnvelope, InsightsStatusData, InsightsSummary, Preset,
+};
 
 #[derive(Parser)]
 #[command(
@@ -58,6 +61,8 @@ enum Commands {
     Stop(NameArgs),
     /// Delete compute and optionally purge the home volume.
     Delete(DeleteArgs),
+    /// Inspect privacy-preserving AI and repository metrics.
+    Metrics(MetricsArgs),
 }
 
 #[derive(Args)]
@@ -126,6 +131,103 @@ struct DeleteArgs {
     yes: bool,
 }
 
+#[derive(Args)]
+struct MetricsArgs {
+    #[command(flatten)]
+    filters: MetricsFilters,
+
+    #[command(subcommand)]
+    command: Option<MetricsCommand>,
+}
+
+#[derive(Args, Clone)]
+struct MetricsFilters {
+    /// Relative range such as 24h, 7d, or 30d, or an RFC 3339 timestamp.
+    #[arg(long, global = true, default_value = "7d")]
+    since: String,
+
+    /// Inclusive RFC 3339 range end (defaults to now).
+    #[arg(long, global = true)]
+    until: Option<String>,
+
+    /// Restrict results to one devbox name.
+    #[arg(long = "box", global = true, value_parser = validate_name)]
+    box_name: Option<String>,
+
+    /// Restrict results to codex or claude.
+    #[arg(long, global = true, value_parser = ["codex", "claude", "all"])]
+    provider: Option<String>,
+
+    /// Restrict results to one provider-reported model.
+    #[arg(long, global = true)]
+    model: Option<String>,
+
+    /// Restrict Git results to one normalized repository identifier.
+    #[arg(long, global = true)]
+    repo: Option<String>,
+
+    /// Request one stable grouping dimension.
+    #[arg(long, global = true, value_enum)]
+    group_by: Option<MetricsGroupBy>,
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum MetricsGroupBy {
+    Provider,
+    Model,
+    Box,
+    Repository,
+}
+
+impl std::fmt::Display for MetricsGroupBy {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Provider => "provider",
+            Self::Model => "model",
+            Self::Box => "box",
+            Self::Repository => "repository",
+        })
+    }
+}
+
+#[derive(Subcommand)]
+enum MetricsCommand {
+    /// Show collector freshness, queue size, and known loss.
+    Status,
+    /// Show aggregate commit activity.
+    Activity {
+        /// Maximum activity rows to return.
+        #[arg(long, default_value_t = 50, value_parser = clap::value_parser!(u16).range(1..=200))]
+        limit: u16,
+    },
+    /// Export the filtered summary to stdout.
+    Export {
+        #[arg(long, value_enum, default_value_t = MetricsExportFormat::Json)]
+        format: MetricsExportFormat,
+    },
+    /// Permanently purge central Insights data for --box.
+    Purge {
+        /// Skip the destructive confirmation prompt.
+        #[arg(long)]
+        yes: bool,
+    },
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum MetricsExportFormat {
+    Json,
+    Csv,
+}
+
+impl std::fmt::Display for MetricsExportFormat {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Json => "json",
+            Self::Csv => "csv",
+        })
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -146,6 +248,7 @@ async fn main() -> Result<()> {
         Commands::Start(args) => lifecycle(&client, &args.name, true, cli.json).await,
         Commands::Stop(args) => lifecycle(&client, &args.name, false, cli.json).await,
         Commands::Delete(args) => delete(&client, args).await,
+        Commands::Metrics(args) => metrics(&client, args, cli.json).await,
     }
 }
 
@@ -349,6 +452,245 @@ async fn delete(client: &ApiClient, args: DeleteArgs) -> Result<()> {
     Ok(())
 }
 
+async fn metrics(client: &ApiClient, args: MetricsArgs, json: bool) -> Result<()> {
+    let MetricsArgs { filters, command } = args;
+    match command {
+        None => {
+            let response = client.insights_summary(&metrics_query(&filters)).await?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&response)?);
+            } else {
+                print_metrics_summary(&response);
+            }
+        }
+        Some(MetricsCommand::Status) => {
+            let response = client.insights_status(&metrics_query(&filters)).await?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&response)?);
+            } else {
+                print_metrics_status(&response);
+            }
+        }
+        Some(MetricsCommand::Activity { limit }) => {
+            let mut query = metrics_query(&filters);
+            query.push(("limit".to_owned(), limit.to_string()));
+            let response = client.insights_activity(&query).await?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&response)?);
+            } else {
+                print_metrics_activity(&response);
+            }
+        }
+        Some(MetricsCommand::Export { format }) => {
+            let mut query = metrics_query(&filters);
+            query.push(("format".to_owned(), format.to_string()));
+            print!("{}", client.insights_export(&query).await?);
+        }
+        Some(MetricsCommand::Purge { yes }) => {
+            let name = filters
+                .box_name
+                .as_deref()
+                .context("metrics purge requires --box NAME")?;
+            if !yes {
+                print!(
+                    "Permanently purge central Insights data for {name}? Type the devbox name to continue: "
+                );
+                io::stdout().flush()?;
+                let mut confirmation = String::new();
+                io::stdin().read_line(&mut confirmation)?;
+                if confirmation.trim() != name {
+                    bail!("confirmation did not match; no Insights data was deleted");
+                }
+            }
+            let result = client.purge_insights(name).await?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&result)?);
+            } else {
+                println!(
+                    "purged {} Insights instance{} for {}",
+                    result.purged_instances,
+                    if result.purged_instances == 1 {
+                        ""
+                    } else {
+                        "s"
+                    },
+                    result.box_name
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn metrics_query(filters: &MetricsFilters) -> Vec<(String, String)> {
+    let mut query = vec![("since".to_owned(), filters.since.clone())];
+    for (key, value) in [
+        ("until", filters.until.as_ref()),
+        ("box", filters.box_name.as_ref()),
+        (
+            "provider",
+            filters
+                .provider
+                .as_ref()
+                .filter(|value| value.as_str() != "all"),
+        ),
+        ("model", filters.model.as_ref()),
+        ("repository", filters.repo.as_ref()),
+    ] {
+        if let Some(value) = value {
+            query.push((key.to_owned(), value.clone()));
+        }
+    }
+    if let Some(group_by) = filters.group_by {
+        query.push(("group_by".to_owned(), group_by.to_string()));
+    }
+    query
+}
+
+fn print_metrics_summary(response: &InsightsEnvelope<InsightsSummary>) {
+    if !response.enabled {
+        println!("Insights is disabled by the operator.");
+        return;
+    }
+    let Some(summary) = &response.data else {
+        println!("No Insights data is available.");
+        return;
+    };
+    let range = response.effective_range.as_ref().map_or_else(
+        || "requested range".to_owned(),
+        |value| format!("{} to {}", value.since, value.until),
+    );
+    println!("INSIGHTS  {range}");
+    let provider_cost = summary
+        .ai
+        .totals
+        .provider_reported_cost_usd
+        .map_or_else(|| "not reported".to_owned(), |value| format!("${value:.4}"));
+    let active_time = summary
+        .ai
+        .totals
+        .active_seconds
+        .map_or_else(|| "not reported".to_owned(), human_duration);
+    let ai_lines = summary
+        .ai
+        .totals
+        .ai_lines
+        .map_or_else(|| "not reported".to_owned(), |value| value.to_string());
+    println!(
+        "AI       {} sessions  {} tokens  {} provider cost  {} active  {} AI lines",
+        summary.ai.totals.sessions, summary.ai.totals.tokens, provider_cost, active_time, ai_lines,
+    );
+    for (provider, values) in &summary.ai.providers {
+        let cost = values
+            .cost_usd
+            .map_or_else(|| "not reported".to_owned(), |value| format!("${value:.4}"));
+        println!(
+            "  {provider:<7} {:>6} sessions  {:>10} tokens  {cost}",
+            values.sessions, values.total_tokens
+        );
+    }
+    let changed = summary.code.working_tree.staged_files + summary.code.working_tree.unstaged_files;
+    println!(
+        "CODE     {} commits  +{} -{}  {} files changed  {} worktree files",
+        summary.code.commits,
+        summary.code.additions,
+        summary.code.deletions,
+        summary.code.files_changed,
+        changed,
+    );
+    println!(
+        "COVERAGE {}  {} collector{}",
+        response.coverage.status,
+        response.coverage.collectors.len(),
+        if response.coverage.collectors.len() == 1 {
+            ""
+        } else {
+            "s"
+        }
+    );
+}
+
+fn print_metrics_status(response: &InsightsEnvelope<InsightsStatusData>) {
+    if !response.enabled {
+        println!("Insights is disabled by the operator.");
+        return;
+    }
+    let collectors: &[CollectorStatus] = response
+        .data
+        .as_ref()
+        .map_or(&[], |data| data.collectors.as_slice());
+    if collectors.is_empty() {
+        println!("No Insights collectors have checked in.");
+        return;
+    }
+    println!(
+        "{:<20} {:<10} {:<10} {:>8} {:>10} LOSS",
+        "BOX", "COLLECTOR", "STATUS", "AGE", "QUEUE"
+    );
+    for collector in collectors {
+        println!(
+            "{:<20} {:<10} {:<10} {:>7}s {:>10} {}",
+            collector.box_name,
+            collector.collector,
+            collector.status,
+            collector.freshness_seconds,
+            collector.queue_bytes,
+            collector.dropped_points,
+        );
+    }
+}
+
+fn print_metrics_activity(response: &InsightsEnvelope<InsightsActivityData>) {
+    if !response.enabled {
+        println!("Insights is disabled by the operator.");
+        return;
+    }
+    let items: &[InsightsActivity] = response
+        .data
+        .as_ref()
+        .map_or(&[], |data| data.items.as_slice());
+    if items.is_empty() {
+        println!("No aggregate Git activity was observed in this range.");
+        return;
+    }
+    for item in items {
+        println!(
+            "{}  {}  {}  +{} -{}  {} file{}{}",
+            item.observed_at,
+            item.box_name,
+            item.repo,
+            item.additions,
+            item.deletions,
+            item.files_changed,
+            if item.files_changed == 1 { "" } else { "s" },
+            if item.is_merge { "  merge" } else { "" },
+        );
+    }
+}
+
+fn human_duration(seconds: f64) -> String {
+    let safe_seconds = if seconds.is_finite() {
+        seconds.max(0.0)
+    } else {
+        0.0
+    };
+    let minutes = Duration::from_secs_f64(safe_seconds)
+        .as_secs()
+        .saturating_add(30)
+        / 60;
+    if minutes < 60 {
+        format!("{minutes}m")
+    } else {
+        let hours = minutes / 60;
+        let remainder = minutes % 60;
+        if remainder == 0 {
+            format!("{hours}h")
+        } else {
+            format!("{hours}h {remainder}m")
+        }
+    }
+}
+
 async fn wait_until_ready(client: &ApiClient, name: &str, timeout: Duration) -> Result<Devbox> {
     let deadline = Instant::now() + timeout;
     loop {
@@ -452,7 +794,12 @@ fn human_expiry(box_info: &Devbox) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_login_token, ssh_arguments, validate_name};
+    use clap::Parser;
+
+    use super::{
+        Cli, Commands, MetricsCommand, human_duration, metrics_query, resolve_login_token,
+        ssh_arguments, validate_name,
+    };
 
     #[test]
     fn login_token_prefers_the_flag_and_supports_the_environment() {
@@ -494,5 +841,61 @@ mod tests {
 
         assert!(forwarding < destination);
         assert!(arguments.contains(&"HostKeyAlias=devboxes-cluster-one-atlas".to_owned()));
+    }
+
+    #[test]
+    fn metrics_filters_are_stable_before_or_after_subcommands() {
+        let summary = Cli::try_parse_from([
+            "devbox",
+            "metrics",
+            "--since",
+            "24h",
+            "--box",
+            "atlas",
+            "--provider",
+            "codex",
+            "--group-by",
+            "model",
+        ])
+        .unwrap();
+        let Commands::Metrics(summary) = summary.command else {
+            panic!("expected metrics command");
+        };
+        assert!(summary.command.is_none());
+        assert_eq!(
+            metrics_query(&summary.filters),
+            vec![
+                ("since".to_owned(), "24h".to_owned()),
+                ("box".to_owned(), "atlas".to_owned()),
+                ("provider".to_owned(), "codex".to_owned()),
+                ("group_by".to_owned(), "model".to_owned()),
+            ]
+        );
+
+        let status = Cli::try_parse_from([
+            "devbox", "metrics", "status", "--box", "atlas", "--since", "7d",
+        ])
+        .unwrap();
+        let Commands::Metrics(status) = status.command else {
+            panic!("expected metrics command");
+        };
+        assert!(matches!(status.command, Some(MetricsCommand::Status)));
+        assert_eq!(status.filters.box_name.as_deref(), Some("atlas"));
+    }
+
+    #[test]
+    fn metrics_rejects_unknown_providers_and_invalid_box_names() {
+        assert!(Cli::try_parse_from(["devbox", "metrics", "--provider", "other"]).is_err());
+        assert!(Cli::try_parse_from(["devbox", "metrics", "--box", "Invalid"]).is_err());
+    }
+
+    #[test]
+    fn active_time_format_is_compact_and_bounded() {
+        assert_eq!(human_duration(0.0), "0m");
+        assert_eq!(human_duration(90.0), "2m");
+        assert_eq!(human_duration(3_600.0), "1h");
+        assert_eq!(human_duration(3_900.0), "1h 5m");
+        assert_eq!(human_duration(-10.0), "0m");
+        assert_eq!(human_duration(f64::NAN), "0m");
     }
 }

--- a/cli/src/models.rs
+++ b/cli/src/models.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, ValueEnum)]
 #[serde(rename_all = "lowercase")]
@@ -77,4 +78,135 @@ pub struct CliTokenResponse {
     pub token_type: String,
     pub expires_in: u64,
     pub scope: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct InsightsEnvelope<T> {
+    pub schema_version: u32,
+    pub generated_at: String,
+    pub enabled: bool,
+    pub effective_range: Option<InsightsRange>,
+    pub coverage: InsightsCoverage,
+    pub capabilities: Value,
+    pub data: Option<T>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct InsightsRange {
+    pub since: String,
+    pub until: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct InsightsCoverage {
+    pub status: String,
+    pub freshness_seconds: Option<u64>,
+    pub collectors: Vec<CollectorStatus>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CollectorStatus {
+    #[serde(rename = "box")]
+    pub box_name: String,
+    pub collector: String,
+    pub version: String,
+    pub status: String,
+    pub capability_reason: Option<String>,
+    pub last_seen_at: String,
+    pub freshness_seconds: u64,
+    pub queue_bytes: u64,
+    pub dropped_batches: u64,
+    pub dropped_points: u64,
+    pub provider_versions: std::collections::BTreeMap<String, String>,
+    pub last_successful_send_at: Option<String>,
+    pub last_error_category: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct InsightsSummary {
+    pub ai: AiSummary,
+    pub code: CodeSummary,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AiSummary {
+    pub totals: AiTotals,
+    pub providers: std::collections::BTreeMap<String, ProviderSummary>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AiTotals {
+    pub sessions: u64,
+    pub tokens: u64,
+    pub provider_reported_cost_usd: Option<f64>,
+    pub active_seconds: Option<f64>,
+    pub ai_lines: Option<u64>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ProviderSummary {
+    pub sessions: u64,
+    pub tokens: std::collections::BTreeMap<String, u64>,
+    pub total_tokens: u64,
+    pub cost_usd: Option<f64>,
+    pub active_seconds: Option<f64>,
+    pub ai_lines: std::collections::BTreeMap<String, u64>,
+    pub models: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CodeSummary {
+    pub commits: u64,
+    pub additions: u64,
+    pub deletions: u64,
+    pub files_changed: u64,
+    pub binary_files: u64,
+    pub working_tree: WorkingTreeSummary,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct WorkingTreeSummary {
+    pub staged_additions: u64,
+    pub staged_deletions: u64,
+    pub staged_files: u64,
+    pub unstaged_additions: u64,
+    pub unstaged_deletions: u64,
+    pub unstaged_files: u64,
+    pub binary_files: u64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct InsightsStatusData {
+    pub collectors: Vec<CollectorStatus>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct InsightsActivityData {
+    pub items: Vec<InsightsActivity>,
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct InsightsActivity {
+    pub id: u64,
+    #[serde(rename = "type")]
+    pub activity_type: String,
+    #[serde(rename = "box")]
+    pub box_name: String,
+    pub repo: String,
+    pub observed_at: String,
+    pub additions: u64,
+    pub deletions: u64,
+    pub files_changed: u64,
+    pub binary_files: u64,
+    pub is_merge: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct InsightsPurgeResult {
+    pub schema_version: u32,
+    pub generated_at: String,
+    #[serde(rename = "box")]
+    pub box_name: String,
+    pub purged_instances: u64,
 }

--- a/controller/pyproject.toml
+++ b/controller/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "devboxes-controller"
-version = "0.2.1"
+version = "0.3.0"
 description = "Controller and dashboard for self-hosted Kubernetes development environments"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -81,6 +81,9 @@ ignore = ["D107", "D203", "D213"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["D", "S101", "S105", "S106"]
+# Query fragments in this module are selected from fixed internal constants and
+# all request values remain bound parameters. "token_type" is a metric category.
+"src/devboxes_controller/insights_store.py" = ["S105", "S608"]
 
 [tool.mypy]
 python_version = "3.12"

--- a/controller/src/devboxes_controller/__init__.py
+++ b/controller/src/devboxes_controller/__init__.py
@@ -1,3 +1,3 @@
 """Devboxes controller package."""
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"

--- a/controller/src/devboxes_controller/app.py
+++ b/controller/src/devboxes_controller/app.py
@@ -1,21 +1,29 @@
 """Create and run the Devboxes HTTP application."""
 
 import asyncio
+import csv
+import io
+import json
 import logging
+import os
+import sqlite3
+import tempfile
 from collections.abc import AsyncIterator, Awaitable
 from contextlib import asynccontextmanager, suppress
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any
 from urllib.parse import urlencode, urlsplit, urlunsplit
 
 import uvicorn
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request, status
 from fastapi import Path as ApiPath
-from fastapi.responses import HTMLResponse, RedirectResponse, Response
+from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from kubernetes.client.exceptions import ApiException
 from prometheus_client import CONTENT_TYPE_LATEST, Gauge, generate_latest
 from pydantic import ValidationError
+from starlette.background import BackgroundTask
 from starlette.middleware.base import RequestResponseEndpoint
 
 from . import __version__
@@ -32,6 +40,13 @@ from .auth import (
     validate_authorization_request,
 )
 from .config import Settings, get_settings
+from .insights_privacy import InsightsPayloadError
+from .insights_service import (
+    InsightsRateLimitError,
+    InsightsService,
+    record_insights_rejection,
+)
+from .insights_store import QueryFilters
 from .manager import DevboxConflictError, DevboxManager, DevboxNotFoundError
 from .models import (
     CliTokenRequest,
@@ -60,10 +75,12 @@ DevboxName = Annotated[
 def create_app(
     settings: Settings | None = None,
     manager: DevboxManager | None = None,
+    insights: InsightsService | None = None,
 ) -> FastAPI:
     """Create a configured FastAPI application and its lifecycle routes."""
     settings = settings or get_settings()
     manager = manager or DevboxManager(settings)
+    insights = insights or InsightsService(settings)
     authenticator = Authenticator(settings)
     authorization_codes = AuthorizationCodeStore(
         ttl_seconds=settings.authorization_code_ttl_seconds,
@@ -73,13 +90,24 @@ def create_app(
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        try:
+            await insights.initialize()
+        except (OSError, sqlite3.Error, ValueError):
+            logger.exception("failed to initialize the Insights store")
         app.state.cleanup_task = asyncio.create_task(
             _cleanup_loop(manager, settings.cleanup_interval_seconds)
+        )
+        app.state.insights_task = (
+            asyncio.create_task(_insights_maintenance_loop(insights)) if insights.enabled else None
         )
         yield
         app.state.cleanup_task.cancel()
         with suppress(asyncio.CancelledError):
             await app.state.cleanup_task
+        if app.state.insights_task is not None:
+            app.state.insights_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await app.state.insights_task
 
     app = FastAPI(
         title="Devboxes",
@@ -112,6 +140,7 @@ def create_app(
         if request.url.path in {
             "/",
             "/docs",
+            "/insights",
             "/login",
             "/auth/login",
         } or request.url.path.startswith(("/api/", "/auth/cli/")):
@@ -126,7 +155,8 @@ def create_app(
 
     @app.get("/ready", tags=["system"])
     async def ready() -> Response:
-        if await manager.ready():
+        manager_ready, insights_ready = await asyncio.gather(manager.ready(), insights.ready())
+        if manager_ready and insights_ready:
             return Response(content='{"status":"ready"}', media_type="application/json")
         return Response(
             content='{"status":"not-ready"}',
@@ -342,6 +372,21 @@ def create_app(
                 "cluster_name": settings.cluster_name,
                 "storage_class": settings.storage_class or "cluster default",
                 "workspace_service_type": settings.workspace_service_type,
+                "version": __version__,
+            },
+        )
+
+    @app.get("/insights", response_class=HTMLResponse, include_in_schema=False)
+    async def insights_dashboard(request: Request) -> Response:
+        if not authenticator.browser_session_valid(request):
+            return RedirectResponse("/login", status_code=status.HTTP_303_SEE_OTHER)
+        return templates.TemplateResponse(
+            request,
+            "insights.html",
+            {
+                "cluster_name": settings.cluster_name,
+                "insights_enabled": insights.enabled,
+                "version": __version__,
             },
         )
 
@@ -370,6 +415,8 @@ def create_app(
                     }
                     for preset, resources in PRESETS.items()
                 ],
+                "insights_enabled": insights.enabled,
+                "version": __version__,
             },
         )
 
@@ -393,7 +440,7 @@ def create_app(
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(error)) from error
         except ValueError as error:
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(error)
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(error)
             ) from error
 
     @app.get("/api/v1/devboxes/{name}", tags=["devboxes"])
@@ -416,7 +463,363 @@ def create_app(
     ) -> DeleteResult:
         return await _not_found(manager.delete(name, purge), name)
 
+    @app.post("/internal/v1/insights/batches", include_in_schema=False)
+    async def ingest_insights_batch(request: Request) -> dict[str, Any]:
+        if not insights.enabled:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+        authorization = request.headers.get("Authorization", "")
+        credential = (
+            authorization.removeprefix("Bearer ").strip()
+            if authorization.startswith("Bearer ")
+            else ""
+        )
+        scope = authenticator.validate_insights_token(credential)
+        if scope is None:
+            record_insights_rejection("authentication")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Authentication required",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        if request.headers.get("Content-Type", "").split(";", 1)[0] != "application/json":
+            record_insights_rejection("media_type")
+            raise HTTPException(
+                status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+                detail="Insights batches must use application/json",
+            )
+        instance_id, box_name = scope
+        try:
+            body = await _read_limited_body(request, settings.insights_max_compressed_bytes)
+            return await insights.ingest(
+                instance_id=instance_id,
+                box_name=box_name,
+                compressed_body=body,
+                content_encoding=request.headers.get("Content-Encoding"),
+            )
+        except HTTPException as error:
+            if error.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE:
+                record_insights_rejection("size")
+            raise
+        except InsightsRateLimitError as error:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail="Insights ingest rate exceeded",
+                headers={"Retry-After": "60"},
+            ) from error
+        except InsightsPayloadError as error:
+            code = (
+                status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+                if "large" in str(error) or "too many" in str(error)
+                else status.HTTP_400_BAD_REQUEST
+            )
+            raise HTTPException(status_code=code, detail=str(error)) from error
+
+    @app.get("/api/v1/insights/summary", tags=["insights"])
+    async def insights_summary(
+        _: Auth,
+        since: Annotated[str, Query(min_length=2, max_length=64)] = "7d",
+        until: Annotated[str | None, Query(max_length=64)] = None,
+        box: Annotated[str | None, Query(max_length=40)] = None,
+        devbox: Annotated[str | None, Query(max_length=40)] = None,
+        instance_id: Annotated[str | None, Query(max_length=36)] = None,
+        provider: Annotated[str | None, Query(pattern="^(codex|claude)$")] = None,
+        model: Annotated[str | None, Query(max_length=160)] = None,
+        repo: Annotated[str | None, Query(max_length=160)] = None,
+        repository: Annotated[str | None, Query(max_length=160)] = None,
+        group_by: Annotated[
+            str | None,
+            Query(pattern="^(provider|model|box|repository|repo)$"),
+        ] = None,
+    ) -> dict[str, Any]:
+        if not insights.enabled:
+            return insights.disabled_envelope()
+        filters = _insights_filters(
+            insights,
+            since,
+            until,
+            _query_alias(box, devbox, "box", "devbox"),
+            provider,
+            model,
+            _query_alias(repo, repository, "repo", "repository"),
+            maximum_days=365,
+            instance_id=instance_id,
+            group_by="repository" if group_by == "repo" else group_by,
+        )
+        return await _with_workspace_insights(manager, await insights.summary(filters), filters)
+
+    @app.get("/api/v1/insights/timeseries", tags=["insights"])
+    async def insights_timeseries(
+        _: Auth,
+        metric: Annotated[str, Query(max_length=32)],
+        since: Annotated[str, Query(min_length=2, max_length=64)] = "7d",
+        until: Annotated[str | None, Query(max_length=64)] = None,
+        box: Annotated[str | None, Query(max_length=40)] = None,
+        devbox: Annotated[str | None, Query(max_length=40)] = None,
+        instance_id: Annotated[str | None, Query(max_length=36)] = None,
+        provider: Annotated[str | None, Query(pattern="^(codex|claude)$")] = None,
+        model: Annotated[str | None, Query(max_length=160)] = None,
+        repo: Annotated[str | None, Query(max_length=160)] = None,
+        repository: Annotated[str | None, Query(max_length=160)] = None,
+        bucket: Annotated[str | None, Query(pattern="^(hour|day)$")] = None,
+    ) -> dict[str, Any]:
+        if not insights.enabled:
+            return insights.disabled_envelope()
+        filters = _insights_filters(
+            insights,
+            since,
+            until,
+            _query_alias(box, devbox, "box", "devbox"),
+            provider,
+            model,
+            _query_alias(repo, repository, "repo", "repository"),
+            maximum_days=365,
+            instance_id=instance_id,
+            bucket=bucket,
+        )
+        try:
+            return await _with_workspace_insights(
+                manager,
+                await insights.timeseries(filters, metric),
+                filters,
+            )
+        except ValueError as error:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=str(error),
+            ) from error
+
+    @app.get("/api/v1/insights/activity", tags=["insights"])
+    async def insights_activity(
+        _: Auth,
+        since: Annotated[str, Query(min_length=2, max_length=64)] = "7d",
+        until: Annotated[str | None, Query(max_length=64)] = None,
+        box: Annotated[str | None, Query(max_length=40)] = None,
+        devbox: Annotated[str | None, Query(max_length=40)] = None,
+        instance_id: Annotated[str | None, Query(max_length=36)] = None,
+        provider: Annotated[str | None, Query(pattern="^(codex|claude)$")] = None,
+        model: Annotated[str | None, Query(max_length=160)] = None,
+        repo: Annotated[str | None, Query(max_length=160)] = None,
+        repository: Annotated[str | None, Query(max_length=160)] = None,
+        cursor: Annotated[str | None, Query(max_length=128)] = None,
+        limit: Annotated[int, Query(ge=1, le=200)] = 50,
+    ) -> dict[str, Any]:
+        if not insights.enabled:
+            return insights.disabled_envelope()
+        filters = _insights_filters(
+            insights,
+            since,
+            until,
+            _query_alias(box, devbox, "box", "devbox"),
+            provider,
+            model,
+            _query_alias(repo, repository, "repo", "repository"),
+            maximum_days=365,
+            instance_id=instance_id,
+        )
+        try:
+            return await _with_workspace_insights(
+                manager,
+                await insights.activity(filters, cursor=cursor, limit=limit),
+                filters,
+            )
+        except ValueError as error:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=str(error),
+            ) from error
+
+    @app.get("/api/v1/insights/capabilities", tags=["insights"])
+    async def insights_capabilities(
+        _: Auth,
+        since: Annotated[str, Query(min_length=2, max_length=64)] = "7d",
+        until: Annotated[str | None, Query(max_length=64)] = None,
+        box: Annotated[str | None, Query(max_length=40)] = None,
+        devbox: Annotated[str | None, Query(max_length=40)] = None,
+        instance_id: Annotated[str | None, Query(max_length=36)] = None,
+        provider: Annotated[str | None, Query(pattern="^(codex|claude)$")] = None,
+        model: Annotated[str | None, Query(max_length=160)] = None,
+        repo: Annotated[str | None, Query(max_length=160)] = None,
+        repository: Annotated[str | None, Query(max_length=160)] = None,
+        group_by: Annotated[
+            str | None,
+            Query(pattern="^(provider|model|box|repository|repo)$"),
+        ] = None,
+    ) -> dict[str, Any]:
+        if not insights.enabled:
+            return insights.disabled_envelope()
+        filters = _insights_filters(
+            insights,
+            since,
+            until,
+            _query_alias(box, devbox, "box", "devbox"),
+            provider,
+            model,
+            _query_alias(repo, repository, "repo", "repository"),
+            maximum_days=365,
+            instance_id=instance_id,
+            group_by="repository" if group_by == "repo" else group_by,
+        )
+        return await _with_workspace_insights(manager, await insights.status(filters), filters)
+
+    @app.get("/api/v1/insights/export", tags=["insights"])
+    async def insights_export(
+        _: Auth,
+        format: Annotated[str, Query(pattern="^(json|csv|sqlite)$")] = "json",
+        since: Annotated[str, Query(min_length=2, max_length=64)] = "30d",
+        until: Annotated[str | None, Query(max_length=64)] = None,
+        box: Annotated[str | None, Query(max_length=40)] = None,
+        devbox: Annotated[str | None, Query(max_length=40)] = None,
+        instance_id: Annotated[str | None, Query(max_length=36)] = None,
+        provider: Annotated[str | None, Query(pattern="^(codex|claude)$")] = None,
+        model: Annotated[str | None, Query(max_length=160)] = None,
+        repo: Annotated[str | None, Query(max_length=160)] = None,
+        repository: Annotated[str | None, Query(max_length=160)] = None,
+        group_by: Annotated[
+            str | None,
+            Query(pattern="^(provider|model|box|repository|repo)$"),
+        ] = None,
+    ) -> Response:
+        if not insights.enabled:
+            return Response(
+                content=json.dumps(insights.disabled_envelope()),
+                media_type="application/json",
+            )
+        filters = _insights_filters(
+            insights,
+            since,
+            until,
+            _query_alias(box, devbox, "box", "devbox"),
+            provider,
+            model,
+            _query_alias(repo, repository, "repo", "repository"),
+            maximum_days=365,
+            instance_id=instance_id,
+            group_by="repository" if group_by == "repo" else group_by,
+        )
+        if format == "sqlite":
+            descriptor, backup_path = tempfile.mkstemp(
+                prefix="devboxes-insights-",
+                suffix=".db",
+                dir="/tmp",
+            )
+            os.close(descriptor)
+            try:
+                await insights.backup(backup_path)
+            except (OSError, sqlite3.Error):
+                await asyncio.to_thread(Path(backup_path).unlink, missing_ok=True)
+                raise
+            return FileResponse(
+                backup_path,
+                media_type="application/vnd.sqlite3",
+                filename="devboxes-insights.db",
+                background=BackgroundTask(Path(backup_path).unlink, missing_ok=True),
+            )
+        envelope = await _with_workspace_insights(
+            manager,
+            await insights.summary(filters),
+            filters,
+        )
+        if format == "json":
+            return Response(
+                content=json.dumps(envelope, sort_keys=True, separators=(",", ":")),
+                media_type="application/json",
+                headers={"Content-Disposition": 'attachment; filename="devboxes-insights.json"'},
+            )
+        return Response(
+            content=_summary_csv(envelope),
+            media_type="text/csv",
+            headers={"Content-Disposition": 'attachment; filename="devboxes-insights.csv"'},
+        )
+
+    @app.delete("/api/v1/insights", tags=["insights"])
+    async def purge_insights_query(
+        _: Auth,
+        instance_id: Annotated[str | None, Query(max_length=36)] = None,
+        box: Annotated[str | None, Query(max_length=40)] = None,
+        devbox: Annotated[str | None, Query(max_length=40)] = None,
+    ) -> dict[str, Any]:
+        if not insights.enabled:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Insights is disabled",
+            )
+        selected_box = _query_alias(box, devbox, "box", "devbox")
+        try:
+            return await insights.purge(selected_box, instance_id=instance_id)
+        except ValueError as error:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=str(error),
+            ) from error
+
+    @app.delete("/api/v1/insights/devboxes/{name}", tags=["insights"])
+    async def purge_insights_compatibility(name: DevboxName, _: Auth) -> dict[str, Any]:
+        if not insights.enabled:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Insights is disabled",
+            )
+        return await insights.purge(box_name=name)
+
     return app
+
+
+async def _with_workspace_insights(
+    manager: DevboxManager,
+    envelope: dict[str, Any],
+    filters: QueryFilters,
+) -> dict[str, Any]:
+    """Merge Kubernetes rollout state into collector coverage without blocking queries."""
+    try:
+        boxes = await manager.list()
+    except (ApiException, OSError):
+        return envelope
+    collectors = list(envelope.get("coverage", {}).get("collectors", []))
+    represented = {str(item.get("box")) for item in collectors}
+    for box in boxes:
+        if filters.box and box.name != filters.box:
+            continue
+        if filters.instance_id and box.instance_id != filters.instance_id:
+            continue
+        state = getattr(box.insights_state, "value", str(box.insights_state))
+        if state == "restart_required":
+            collector_state = "restart_required"
+            reason = "A normal stop and start is required to install the collector"
+        elif state == "collecting" and box.name not in represented:
+            collector_state = "partial"
+            reason = "Waiting for the first collector batch"
+        else:
+            continue
+        collectors.append(
+            {
+                "box": box.name,
+                "collector": "workspace",
+                "version": "unavailable",
+                "status": collector_state,
+                "capability_reason": reason,
+                "last_seen_at": envelope["generated_at"],
+                "freshness_seconds": 0,
+                "queue_bytes": 0,
+                "dropped_batches": 0,
+                "dropped_points": 0,
+                "provider_versions": {},
+                "last_successful_send_at": None,
+                "last_error_category": None,
+            }
+        )
+    coverage = envelope.get("coverage", {})
+    coverage["collectors"] = collectors
+    states = {str(item.get("status")) for item in collectors}
+    if "stale" in states:
+        coverage["status"] = "stale"
+    elif states & {"partial", "restart_required", "data_loss_detected"}:
+        coverage["status"] = "partial"
+    elif collectors:
+        coverage["status"] = "fresh"
+    data = envelope.get("data")
+    if isinstance(data, dict) and "collectors" in data:
+        data["collectors"] = collectors
+    return envelope
 
 
 async def _not_found[T](awaitable: Awaitable[T], name: str) -> T:
@@ -436,13 +839,128 @@ def _append_redirect_query(redirect_uri: str, values: dict[str, str]) -> str:
 
 async def _cleanup_loop(manager: DevboxManager, interval: int) -> None:
     while True:
-        await asyncio.sleep(interval)
         try:
+            reconciled = await manager.reconcile_insights()
+            for name in reconciled:
+                logger.info("reconciled Insights state for devbox %s", name)
             stopped = await manager.stop_expired()
             for name in stopped:
                 logger.info("auto-stopped expired devbox %s", name)
         except Exception:
             logger.exception("failed to check expired devboxes")
+        await asyncio.sleep(interval)
+
+
+async def _insights_maintenance_loop(insights: InsightsService) -> None:
+    while True:
+        await asyncio.sleep(3600)
+        try:
+            result = await insights.maintain()
+            logger.info("completed Insights maintenance: %s", result)
+        except (OSError, sqlite3.Error, ValueError):
+            logger.exception("failed to maintain the Insights store")
+
+
+async def _read_limited_body(request: Request, maximum: int) -> bytes:
+    length = request.headers.get("Content-Length")
+    if length is not None:
+        try:
+            if int(length) > maximum:
+                raise HTTPException(
+                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                    detail="compressed batch is too large",
+                )
+        except ValueError as error:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid Content-Length",
+            ) from error
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in request.stream():
+        total += len(chunk)
+        if total > maximum:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail="compressed batch is too large",
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _insights_filters(
+    insights: InsightsService,
+    since: str,
+    until: str | None,
+    box: str | None,
+    provider: str | None,
+    model: str | None,
+    repo: str | None,
+    *,
+    maximum_days: int,
+    instance_id: str | None = None,
+    group_by: str | None = None,
+    bucket: str | None = None,
+) -> QueryFilters:
+    try:
+        return insights.filters(
+            since=since,
+            until=until,
+            box=box,
+            provider=provider,
+            model=model,
+            repo=repo,
+            maximum_days=maximum_days,
+            instance_id=instance_id,
+            group_by=group_by,
+            bucket=bucket,
+        )
+    except (InsightsPayloadError, ValueError) as error:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(error),
+        ) from error
+
+
+def _query_alias(
+    short: str | None,
+    descriptive: str | None,
+    short_name: str,
+    descriptive_name: str,
+) -> str | None:
+    if short is not None and descriptive is not None and short != descriptive:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"{short_name} and {descriptive_name} must match when both are supplied",
+        )
+    return descriptive if descriptive is not None else short
+
+
+def _summary_csv(envelope: dict[str, Any]) -> str:
+    output = io.StringIO(newline="")
+    writer = csv.writer(output, lineterminator="\n")
+    writer.writerow(("category", "provider", "metric", "value"))
+    data = envelope.get("data") or {}
+    ai = data.get("ai") or {}
+    for provider, values in sorted((ai.get("providers") or {}).items()):
+        for metric in ("sessions", "total_tokens", "cost_usd", "active_seconds"):
+            value = values.get(metric)
+            if value is not None:
+                writer.writerow(("ai", _csv_cell(provider), metric, _csv_cell(value)))
+        for token_type, value in sorted((values.get("tokens") or {}).items()):
+            writer.writerow(("ai", _csv_cell(provider), f"tokens.{token_type}", _csv_cell(value)))
+    for metric, value in sorted((data.get("code") or {}).items()):
+        if isinstance(value, dict):
+            for child, child_value in sorted(value.items()):
+                writer.writerow(("code", "git", f"{metric}.{child}", _csv_cell(child_value)))
+        else:
+            writer.writerow(("code", "git", metric, _csv_cell(value)))
+    return output.getvalue()
+
+
+def _csv_cell(value: object) -> str:
+    text = str(value)
+    return f"'{text}" if text.startswith(("=", "+", "-", "@")) else text
 
 
 def main() -> None:

--- a/controller/src/devboxes_controller/auth.py
+++ b/controller/src/devboxes_controller/auth.py
@@ -34,6 +34,11 @@ _STATE_RE = re.compile(r"^[A-Za-z0-9_-]{32,256}$")
 _PKCE_RE = re.compile(r"^[A-Za-z0-9._~-]{43,128}$")
 _CODE_RE = re.compile(r"^[A-Za-z0-9_-]{32,256}$")
 _SIGNING_DOMAIN = b"devboxes:cli-token-signing-key:v1"
+_INSIGHTS_SIGNING_DOMAIN = b"devboxes:insights-ingest-signing-key:v1"
+_INSIGHTS_TOKEN_RE = re.compile(
+    r"^v1\.([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\."
+    r"([a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?)\.([A-Za-z0-9_-]{43})$"
+)
 
 
 @dataclass(frozen=True)
@@ -167,6 +172,15 @@ class Authenticator:
             configured_signing_key
             or hmac.new(self._token, _SIGNING_DOMAIN, hashlib.sha256).digest()
         )
+        configured_insights_key = (
+            settings.insights_signing_key.get_secret_value().encode()
+            if settings.insights_signing_key is not None
+            else None
+        )
+        self._insights_signing_key = (
+            configured_insights_key
+            or hmac.new(self._token, _INSIGHTS_SIGNING_DOMAIN, hashlib.sha256).digest()
+        )
 
     def issue_session(self) -> tuple[str, str]:
         """Issue a signed browser session and its matching CSRF token."""
@@ -246,6 +260,36 @@ class Authenticator:
             return str(claims["sub"])
         except (InvalidTokenError, TypeError, ValueError):
             return None
+
+    def issue_insights_token(self, instance_id: str, box_name: str) -> str:
+        """Issue a deterministic, write-only token scoped to one retained instance."""
+        payload = f"v1.{instance_id}.{box_name}"
+        signature = hmac.new(
+            self._insights_signing_key,
+            payload.encode(),
+            hashlib.sha256,
+        ).digest()
+        return f"{payload}.{_b64(signature)}"
+
+    def validate_insights_token(self, candidate: str) -> tuple[str, str] | None:
+        """Validate an ingest-only credential and return its authoritative scope."""
+        match = _INSIGHTS_TOKEN_RE.fullmatch(candidate)
+        if match is None:
+            return None
+        instance_id, box_name, encoded_signature = match.groups()
+        payload = f"v1.{instance_id}.{box_name}"
+        try:
+            signature = _unb64(encoded_signature)
+        except ValueError:
+            return None
+        expected = hmac.new(
+            self._insights_signing_key,
+            payload.encode(),
+            hashlib.sha256,
+        ).digest()
+        if not hmac.compare_digest(signature, expected):
+            return None
+        return instance_id, box_name
 
     def validate_session(self, candidate: str) -> str | None:
         """Return the CSRF value for a valid unexpired session."""

--- a/controller/src/devboxes_controller/config.py
+++ b/controller/src/devboxes_controller/config.py
@@ -38,6 +38,26 @@ class Settings(BaseSettings):
     authorization_code_store_size: int = Field(default=1024, ge=16, le=10_000)
     cli_token_ttl_seconds: int = Field(default=2_592_000, ge=300, le=31_536_000)
     cli_signing_key: SecretStr | None = None
+    insights_enabled: bool = False
+    insights_db_path: str = "/var/lib/devboxes/insights.db"
+    insights_database_warning_bytes: int = Field(
+        default=1_717_986_918,
+        ge=1_048_576,
+        le=1_099_511_627_776,
+    )
+    insights_controller_url: str = "http://devboxes:8000"
+    insights_signing_key: SecretStr | None = None
+    insights_retention_raw_days: int = Field(default=30, ge=1, le=365)
+    insights_retention_hourly_days: int = Field(default=90, ge=1, le=730)
+    insights_retention_daily_days: int = Field(default=365, ge=1, le=3650)
+    insights_agent_scan_interval_seconds: int = Field(default=60, ge=15, le=3600)
+    insights_agent_repository_depth: int = Field(default=4, ge=1, le=12)
+    insights_agent_max_queue_bytes: int = Field(default=134_217_728, ge=1_048_576, le=2_147_483_648)
+    insights_agent_max_queue_age_seconds: int = Field(default=604_800, ge=60, le=31_536_000)
+    insights_max_compressed_bytes: int = Field(default=2_097_152, ge=1024, le=16_777_216)
+    insights_max_expanded_bytes: int = Field(default=8_388_608, ge=4096, le=67_108_864)
+    insights_max_points_per_batch: int = Field(default=10_000, ge=1, le=100_000)
+    insights_ingest_rate_per_minute: int = Field(default=120, ge=1, le=10_000)
     cookie_secure: bool = True
     kubeconfig_context: str | None = None
     log_level: str = "INFO"
@@ -58,6 +78,7 @@ class Settings(BaseSettings):
         "workspace_load_balancer_class",
         "kubeconfig_context",
         "cli_signing_key",
+        "insights_signing_key",
         mode="before",
     )
     @classmethod
@@ -100,6 +121,32 @@ class Settings(BaseSettings):
             raise ValueError("CLI signing key must contain at least 32 characters")
         return value
 
+    @field_validator("insights_signing_key")
+    @classmethod
+    def insights_signing_key_is_strong(cls, value: SecretStr | None) -> SecretStr | None:
+        """Require a dedicated ingest key to carry strong entropy when set."""
+        if value is not None and len(value.get_secret_value().strip()) < 32:
+            raise ValueError("Insights signing key must contain at least 32 characters")
+        return value
+
+    @field_validator("insights_db_path")
+    @classmethod
+    def insights_db_path_is_absolute(cls, value: str) -> str:
+        """Keep the central database on an explicit mounted filesystem path."""
+        if not value.startswith("/"):
+            raise ValueError("insights_db_path must be absolute")
+        return value
+
+    @field_validator("insights_controller_url")
+    @classmethod
+    def insights_controller_url_is_http(cls, value: str) -> str:
+        """Require an absolute internal HTTP URL used only by workspace agents."""
+        value = value.strip().rstrip("/")
+        parsed = urlsplit(value)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("insights_controller_url must be an absolute http or https URL")
+        return value
+
     @field_validator("access_token")
     @classmethod
     def access_token_is_not_blank(cls, value: SecretStr) -> SecretStr:
@@ -116,6 +163,14 @@ class Settings(BaseSettings):
             raise ValueError("default_ttl_hours cannot exceed max_ttl_hours")
         if self.workspace_service_type == "NodePort" and not self.workspace_service_host:
             raise ValueError("workspace_service_host is required for NodePort services")
+        if not (
+            self.insights_retention_raw_days
+            <= self.insights_retention_hourly_days
+            <= self.insights_retention_daily_days
+        ):
+            raise ValueError("Insights retention must satisfy rawDays <= hourlyDays <= dailyDays")
+        if self.insights_max_compressed_bytes > self.insights_max_expanded_bytes:
+            raise ValueError("Insights compressed limit cannot exceed expanded limit")
         return self
 
 

--- a/controller/src/devboxes_controller/insights_privacy.py
+++ b/controller/src/devboxes_controller/insights_privacy.py
@@ -1,0 +1,359 @@
+"""Apply the Insights telemetry allowlist before data reaches durable storage."""
+
+from __future__ import annotations
+
+import copy
+import math
+import re
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+
+class InsightsPayloadError(ValueError):
+    """Signal a malformed or oversized Insights payload without echoing its content."""
+
+
+_SAFE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,159}$")
+_SAFE_VALUE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,159}$")
+_ATTRIBUTE_ALIASES = {
+    "provider": "provider",
+    "model": "model",
+    "gen_ai.request.model": "model",
+    "auth_mode": "auth_mode",
+    "session_source": "session_source",
+    "query_source": "session_source",
+    "app.version": "app.version",
+    "service.version": "app.version",
+    "token_type": "token_type",
+    "type": "type",
+    "tool": "tool",
+    "tool_name": "tool",
+    "success": "success",
+    "status": "status",
+    "start_type": "start_type",
+    "decision": "decision",
+}
+_RESOURCE_ATTRIBUTES = {"service.name", "service.version"}
+_POINT_SCALAR_FIELDS = {
+    "startTimeUnixNano",
+    "timeUnixNano",
+    "asDouble",
+    "asInt",
+    "count",
+    "sum",
+    "min",
+    "max",
+    "scale",
+    "zeroCount",
+    "zeroThreshold",
+    "flags",
+}
+_POINT_ARRAY_FIELDS = {"bucketCounts", "explicitBounds"}
+
+
+def sanitize_otlp(payload: object, *, maximum_points: int) -> tuple[dict[str, Any], int]:
+    """Return a metrics-only OTLP/JSON document containing allowlisted data."""
+    if not isinstance(payload, dict):
+        raise InsightsPayloadError("invalid OTLP metrics payload")
+    resource_metrics = payload.get("resourceMetrics")
+    if not isinstance(resource_metrics, list) or not resource_metrics:
+        raise InsightsPayloadError("invalid OTLP metrics payload")
+
+    sanitized_resources: list[dict[str, Any]] = []
+    point_count = 0
+    for resource_metric in resource_metrics:
+        if not isinstance(resource_metric, dict):
+            raise InsightsPayloadError("invalid OTLP metrics payload")
+        scope_metrics = resource_metric.get("scopeMetrics")
+        if not isinstance(scope_metrics, list):
+            raise InsightsPayloadError("invalid OTLP metrics payload")
+        sanitized_scopes: list[dict[str, Any]] = []
+        for scope_metric in scope_metrics:
+            if not isinstance(scope_metric, dict):
+                raise InsightsPayloadError("invalid OTLP metrics payload")
+            metrics = scope_metric.get("metrics")
+            if not isinstance(metrics, list):
+                raise InsightsPayloadError("invalid OTLP metrics payload")
+            sanitized_metrics: list[dict[str, Any]] = []
+            for metric in metrics:
+                sanitized_metric, metric_points = _sanitize_metric(metric)
+                point_count += metric_points
+                if point_count > maximum_points:
+                    raise InsightsPayloadError("too many metric points")
+                if metric_points:
+                    sanitized_metrics.append(sanitized_metric)
+            if sanitized_metrics:
+                sanitized_scope: dict[str, Any] = {"metrics": sanitized_metrics}
+                scope = _sanitize_scope(scope_metric.get("scope"))
+                if scope:
+                    sanitized_scope["scope"] = scope
+                sanitized_scopes.append(sanitized_scope)
+        if sanitized_scopes:
+            sanitized_resource: dict[str, Any] = {"scopeMetrics": sanitized_scopes}
+            resource = _sanitize_resource(resource_metric.get("resource"))
+            if resource:
+                sanitized_resource["resource"] = resource
+            sanitized_resources.append(sanitized_resource)
+
+    if not sanitized_resources or point_count == 0:
+        raise InsightsPayloadError("OTLP payload has no metric points")
+    return {"resourceMetrics": sanitized_resources}, point_count
+
+
+def sanitize_git_payload(payload: object, *, maximum_commits: int = 10_000) -> dict[str, Any]:
+    """Validate an aggregate-only Git collector payload at the trust boundary."""
+    if not isinstance(payload, dict) or not isinstance(payload.get("repositories"), list):
+        raise InsightsPayloadError("invalid Git collector payload")
+    if len(payload["repositories"]) > 10_000:
+        raise InsightsPayloadError("too many repository aggregates")
+    repositories: list[dict[str, Any]] = []
+    commit_count = 0
+    for candidate in payload["repositories"]:
+        if not isinstance(candidate, dict):
+            raise InsightsPayloadError("invalid Git collector payload")
+        repo_key = candidate.get("repo_key")
+        if not isinstance(repo_key, str) or not _SAFE_VALUE.fullmatch(repo_key):
+            raise InsightsPayloadError("invalid repository identifier")
+        commits: list[dict[str, Any]] = []
+        for commit in candidate.get("commits", []):
+            if not isinstance(commit, dict):
+                raise InsightsPayloadError("invalid commit aggregate")
+            sha = commit.get("sha")
+            committed_at = commit.get("committed_at")
+            if not isinstance(sha, str) or not re.fullmatch(r"[0-9a-f]{40,64}", sha):
+                raise InsightsPayloadError("invalid commit aggregate")
+            if not isinstance(committed_at, str) or len(committed_at) > 40:
+                raise InsightsPayloadError("invalid commit aggregate")
+            try:
+                parsed_at = datetime.fromisoformat(committed_at.replace("Z", "+00:00"))
+            except ValueError as error:
+                raise InsightsPayloadError("invalid commit aggregate") from error
+            if parsed_at.tzinfo is None:
+                raise InsightsPayloadError("invalid commit aggregate")
+            parsed_at = parsed_at.astimezone(UTC)
+            if parsed_at < datetime(2020, 1, 1, tzinfo=UTC) or parsed_at > datetime.now(
+                UTC
+            ) + timedelta(minutes=5):
+                raise InsightsPayloadError("invalid commit aggregate")
+            is_merge = commit.get("is_merge", False)
+            if not isinstance(is_merge, bool):
+                raise InsightsPayloadError("invalid commit aggregate")
+            sanitized_commit = {
+                "sha": sha,
+                "committed_at": parsed_at.isoformat(),
+                "additions": _bounded_int(commit.get("additions"), maximum=1_000_000_000),
+                "deletions": _bounded_int(commit.get("deletions"), maximum=1_000_000_000),
+                "files_changed": _bounded_int(commit.get("files_changed"), maximum=10_000_000),
+                "binary_files": _bounded_int(commit.get("binary_files"), maximum=10_000_000),
+                "is_merge": is_merge,
+            }
+            commits.append(sanitized_commit)
+            commit_count += 1
+            if commit_count > maximum_commits:
+                raise InsightsPayloadError("too many commit aggregates")
+        working_tree = candidate.get("working_tree")
+        sanitized_tree: dict[str, int] | None = None
+        if working_tree is not None:
+            if not isinstance(working_tree, dict):
+                raise InsightsPayloadError("invalid working tree aggregate")
+            sanitized_tree = {
+                key: _bounded_int(working_tree.get(key), maximum=1_000_000_000)
+                for key in (
+                    "staged_additions",
+                    "staged_deletions",
+                    "staged_files",
+                    "unstaged_additions",
+                    "unstaged_deletions",
+                    "unstaged_files",
+                    "binary_files",
+                )
+            }
+        repositories.append(
+            {
+                "repo_key": repo_key,
+                "commits": commits,
+                "working_tree": sanitized_tree,
+            }
+        )
+    return {"repositories": repositories}
+
+
+def contains_sensitive_key(payload: object) -> bool:
+    """Return whether a recursively inspected payload contains a forbidden key."""
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = str(key).lower().replace("-", "_")
+            if any(
+                fragment in normalized
+                for fragment in (
+                    "prompt",
+                    "command",
+                    "content",
+                    "user_id",
+                    "account",
+                    "session_id",
+                    "path",
+                    "url",
+                    "input",
+                    "output",
+                    "error_body",
+                    "request_body",
+                    "response_body",
+                )
+            ):
+                return True
+            if contains_sensitive_key(value):
+                return True
+    elif isinstance(payload, list):
+        return any(contains_sensitive_key(item) for item in payload)
+    return False
+
+
+def _sanitize_metric(candidate: object) -> tuple[dict[str, Any], int]:
+    if not isinstance(candidate, dict):
+        raise InsightsPayloadError("invalid metric")
+    name = candidate.get("name")
+    if not isinstance(name, str) or not _SAFE_NAME.fullmatch(name):
+        raise InsightsPayloadError("invalid metric name")
+    sanitized: dict[str, Any] = {"name": name}
+    unit = candidate.get("unit")
+    if isinstance(unit, str) and len(unit) <= 32 and (not unit or _SAFE_VALUE.fullmatch(unit)):
+        sanitized["unit"] = unit
+
+    point_count = 0
+    for form in ("gauge", "sum", "histogram", "exponentialHistogram", "summary"):
+        value = candidate.get(form)
+        if value is None:
+            continue
+        if not isinstance(value, dict) or not isinstance(value.get("dataPoints"), list):
+            raise InsightsPayloadError("invalid metric data")
+        points = [_sanitize_point(point) for point in value["dataPoints"]]
+        point_count += len(points)
+        data: dict[str, Any] = {"dataPoints": points}
+        if form in {"sum", "histogram", "exponentialHistogram"}:
+            temporality = value.get("aggregationTemporality")
+            if temporality in {0, 1, 2, "0", "1", "2"}:
+                data["aggregationTemporality"] = int(str(temporality))
+        if form == "sum" and isinstance(value.get("isMonotonic"), bool):
+            data["isMonotonic"] = value["isMonotonic"]
+        sanitized[form] = data
+    if point_count == 0:
+        return sanitized, 0
+    return sanitized, point_count
+
+
+def _sanitize_point(candidate: object) -> dict[str, Any]:
+    if not isinstance(candidate, dict):
+        raise InsightsPayloadError("invalid metric point")
+    point: dict[str, Any] = {}
+    attributes = _sanitize_attributes(candidate.get("attributes"), resource=False)
+    if attributes:
+        point["attributes"] = attributes
+    for key in _POINT_SCALAR_FIELDS:
+        if key in candidate:
+            point[key] = _numeric(candidate[key], key)
+    for key in _POINT_ARRAY_FIELDS:
+        if key in candidate:
+            value = candidate[key]
+            if not isinstance(value, list) or len(value) > 20_000:
+                raise InsightsPayloadError("invalid metric point")
+            point[key] = [_numeric(item, key) for item in value]
+    for key in ("positive", "negative"):
+        if key in candidate:
+            value = candidate[key]
+            if not isinstance(value, dict):
+                raise InsightsPayloadError("invalid metric point")
+            counts = value.get("bucketCounts", [])
+            if not isinstance(counts, list) or len(counts) > 20_000:
+                raise InsightsPayloadError("invalid metric point")
+            point[key] = {
+                "offset": _numeric(value.get("offset", 0), "offset"),
+                "bucketCounts": [_numeric(item, "bucketCounts") for item in counts],
+            }
+    if "quantileValues" in candidate:
+        values = candidate["quantileValues"]
+        if not isinstance(values, list) or len(values) > 10_000:
+            raise InsightsPayloadError("invalid metric point")
+        point["quantileValues"] = [
+            {
+                "quantile": _numeric(item.get("quantile"), "quantile"),
+                "value": _numeric(item.get("value"), "value"),
+            }
+            for item in values
+            if isinstance(item, dict)
+        ]
+    if not any(key in point for key in ("asInt", "asDouble", "sum", "count")):
+        raise InsightsPayloadError("metric point has no numeric value")
+    return point
+
+
+def _sanitize_resource(candidate: object) -> dict[str, Any] | None:
+    if not isinstance(candidate, dict):
+        return None
+    attributes = _sanitize_attributes(candidate.get("attributes"), resource=True)
+    return {"attributes": attributes} if attributes else None
+
+
+def _sanitize_scope(candidate: object) -> dict[str, str] | None:
+    if not isinstance(candidate, dict):
+        return None
+    result: dict[str, str] = {}
+    for key in ("name", "version"):
+        value = candidate.get(key)
+        if isinstance(value, str) and _SAFE_VALUE.fullmatch(value):
+            result[key] = value
+    return result or None
+
+
+def _sanitize_attributes(candidate: object, *, resource: bool) -> list[dict[str, Any]]:
+    if not isinstance(candidate, list):
+        return []
+    result: dict[str, dict[str, Any]] = {}
+    for item in candidate:
+        if not isinstance(item, dict) or not isinstance(item.get("key"), str):
+            continue
+        original_key = item["key"]
+        if resource:
+            if original_key not in _RESOURCE_ATTRIBUTES:
+                continue
+            key = original_key
+        else:
+            key = _ATTRIBUTE_ALIASES.get(original_key, "")
+            if not key:
+                continue
+        value = _sanitize_any_value(item.get("value"))
+        if value is not None:
+            result[key] = {"key": key, "value": value}
+    return [result[key] for key in sorted(result)]
+
+
+def _sanitize_any_value(candidate: object) -> dict[str, Any] | None:
+    if not isinstance(candidate, dict):
+        return None
+    if isinstance(candidate.get("boolValue"), bool):
+        return {"boolValue": candidate["boolValue"]}
+    for key in ("intValue", "doubleValue"):
+        if key in candidate:
+            return {key: _numeric(candidate[key], key)}
+    value = candidate.get("stringValue")
+    if isinstance(value, str) and _SAFE_VALUE.fullmatch(value):
+        return {"stringValue": value}
+    return None
+
+
+def _numeric(value: object, field: str) -> int | float | str:
+    if isinstance(value, bool):
+        raise InsightsPayloadError(f"invalid numeric {field}")
+    if isinstance(value, float) and not math.isfinite(value):
+        raise InsightsPayloadError(f"invalid numeric {field}")
+    if isinstance(value, (int, float)):
+        return copy.copy(value)
+    if isinstance(value, str) and re.fullmatch(r"-?[0-9]{1,30}(?:\.[0-9]+)?", value):
+        return value
+    raise InsightsPayloadError(f"invalid numeric {field}")
+
+
+def _bounded_int(value: object, *, maximum: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or not 0 <= value <= maximum:
+        raise InsightsPayloadError("invalid aggregate count")
+    return value

--- a/controller/src/devboxes_controller/insights_service.py
+++ b/controller/src/devboxes_controller/insights_service.py
@@ -1,0 +1,656 @@
+"""Coordinate authenticated Insights ingestion, queries, and capability reporting."""
+
+from __future__ import annotations
+
+import asyncio
+import gzip
+import io
+import json
+import re
+import sqlite3
+import time
+import uuid
+from collections import defaultdict, deque
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Final
+
+from prometheus_client import Counter, Gauge, Histogram
+
+from .config import Settings
+from .insights_privacy import InsightsPayloadError, sanitize_git_payload, sanitize_otlp
+from .insights_store import SCHEMA_VERSION, InsightsStore, QueryFilters
+
+INSIGHTS_INGEST_ACCEPTED = Counter(
+    "devboxes_insights_ingest_batches_total",
+    "Accepted Insights batches by safe provider category",
+    ["provider"],
+)
+INSIGHTS_INGEST_DROPPED = Counter(
+    "devboxes_insights_dropped_batches_total",
+    "Rejected or duplicate Insights batches by safe provider category",
+    ["provider"],
+)
+INSIGHTS_DB_SECONDS = Histogram(
+    "devboxes_insights_db_operation_seconds",
+    "Time spent in Insights database operations",
+)
+INSIGHTS_ROLLUP_SECONDS = Histogram(
+    "devboxes_insights_rollup_seconds",
+    "Time spent maintaining Insights retention and rollups",
+)
+INSIGHTS_STORE_READY = Gauge(
+    "devboxes_insights_store_ready",
+    "Whether the enabled Insights store is ready",
+)
+INSIGHTS_INGEST_RESULTS = Counter(
+    "devboxes_insights_ingest_results_total",
+    "Insights ingest requests by bounded result category",
+    ["result"],
+)
+INSIGHTS_INGEST_ERRORS = Counter(
+    "devboxes_insights_ingest_errors_total",
+    "Insights ingest failures by bounded reason category",
+    ["reason"],
+)
+INSIGHTS_DATABASE_BYTES = Gauge(
+    "devboxes_insights_database_bytes",
+    "Current Insights SQLite main, WAL, and shared-memory bytes",
+)
+INSIGHTS_LAST_ROLLUP = Gauge(
+    "devboxes_insights_last_successful_rollup_timestamp_seconds",
+    "Unix timestamp of the last successful Insights maintenance pass",
+)
+INSIGHTS_DROPPED_POINTS = Gauge(
+    "devboxes_insights_dropped_points",
+    "Collector-reported dropped points by bounded provider category",
+    ["provider"],
+)
+
+_BATCH_ID_RE: Final = re.compile(r"^[0-9a-f]{64}$")
+_COLLECTORS: Final = {"otel", "git", "agent"}
+_KINDS: Final = {"otlp", "git", "heartbeat"}
+_SAFE_STATUS: Final = {"ok", "degraded", "disabled"}
+_SAFE_CAPABILITY_REASONS: Final = {
+    "git unavailable",
+    "no repositories discovered",
+    "collector degraded",
+    "queue loss detected",
+}
+_SAFE_ERROR_CATEGORIES: Final = {"network", "rate_limited", "rejected", "server"}
+_SUPPORTED_TIMESERIES: Final = {
+    "sessions",
+    "tokens",
+    "cost",
+    "active_time",
+    "ai_lines",
+    "git_commits",
+    "git_churn",
+}
+
+
+class InsightsDisabledError(RuntimeError):
+    """Signal that an Insights-only operation is unavailable by configuration."""
+
+
+class InsightsRateLimitError(RuntimeError):
+    """Signal that an instance exceeded its bounded ingest request rate."""
+
+
+class InsightsService:
+    """Own the optional central store and its privacy-preserving API contract."""
+
+    def __init__(self, settings: Settings, store: InsightsStore | None = None) -> None:
+        self.settings = settings
+        self.enabled = settings.insights_enabled
+        self.store = store or InsightsStore(
+            settings.insights_db_path,
+            raw_days=settings.insights_retention_raw_days,
+            hourly_days=settings.insights_retention_hourly_days,
+            daily_days=settings.insights_retention_daily_days,
+        )
+        self._rates: dict[str, deque[float]] = defaultdict(deque)
+        self._rate_lock = asyncio.Lock()
+
+    async def initialize(self) -> None:
+        """Initialize the store only when the operator explicitly opted in."""
+        if not self.enabled:
+            INSIGHTS_STORE_READY.set(0)
+            INSIGHTS_DATABASE_BYTES.set(0)
+            return
+        await self.store.initialize()
+        INSIGHTS_STORE_READY.set(1)
+        INSIGHTS_DATABASE_BYTES.set(await self.store.database_size())
+
+    async def ready(self) -> bool:
+        """Return true when disabled or when the enabled central store is healthy."""
+        if not self.enabled:
+            return True
+        result = await self.store.ready()
+        INSIGHTS_STORE_READY.set(int(result))
+        return result
+
+    async def check_rate(self, instance_id: str) -> None:
+        """Apply a bounded in-process per-credential request rate."""
+        now = time.monotonic()
+        cutoff = now - 60
+        async with self._rate_lock:
+            entries = self._rates[instance_id]
+            while entries and entries[0] < cutoff:
+                entries.popleft()
+            if len(entries) >= self.settings.insights_ingest_rate_per_minute:
+                raise InsightsRateLimitError
+            entries.append(now)
+            if len(self._rates) > 20_000:
+                self._rates = defaultdict(
+                    deque,
+                    {
+                        key: value
+                        for key, value in self._rates.items()
+                        if value and value[-1] >= cutoff
+                    },
+                )
+
+    async def ingest(
+        self,
+        *,
+        instance_id: str,
+        box_name: str,
+        compressed_body: bytes,
+        content_encoding: str | None,
+    ) -> dict[str, Any]:
+        """Decode, sanitize, and transactionally persist one authenticated batch."""
+        self._require_enabled()
+        try:
+            await self.check_rate(instance_id)
+            batch = self._decode_batch(compressed_body, content_encoding)
+            kind = str(batch["kind"])
+            collector = str(batch["collector"])
+            payload, point_count = self._sanitize_payload(kind, batch["payload"])
+            payload.update(_collector_metadata(batch))
+            started = time.perf_counter()
+            result = await self.store.ingest(
+                instance_id=instance_id,
+                box_name=box_name,
+                batch_id=str(batch["batch_id"]),
+                collector=collector,
+                kind=kind,
+                sent_at=_parse_timestamp(str(batch["sent_at"])),
+                payload=payload,
+                reported_points=point_count,
+            )
+        except InsightsRateLimitError:
+            record_insights_rejection("rate_limit")
+            raise
+        except InsightsPayloadError as error:
+            reason = "size" if "large" in str(error) or "too many" in str(error) else "validation"
+            record_insights_rejection(reason)
+            raise
+        except ValueError as error:
+            record_insights_rejection("validation")
+            raise InsightsPayloadError("batch identifier conflict") from error
+        except (OSError, sqlite3.Error):
+            record_insights_rejection("storage")
+            raise
+        INSIGHTS_DB_SECONDS.observe(time.perf_counter() - started)
+        providers = result.providers or (("git",) if kind == "git" else ("unknown",))
+        counter = INSIGHTS_INGEST_DROPPED if result.duplicate else INSIGHTS_INGEST_ACCEPTED
+        INSIGHTS_INGEST_RESULTS.labels(result="duplicate" if result.duplicate else "accepted").inc()
+        for provider in providers:
+            safe_provider = _safe_provider(provider)
+            counter.labels(provider=safe_provider).inc()
+            INSIGHTS_DROPPED_POINTS.labels(provider=safe_provider).set(
+                int(payload.get("dropped_points", 0))
+            )
+        INSIGHTS_DATABASE_BYTES.set(await self.store.database_size())
+        return {
+            "accepted": result.accepted,
+            "duplicate": result.duplicate,
+            "points": result.points,
+        }
+
+    async def summary(self, filters: QueryFilters) -> dict[str, Any]:
+        """Return the stable summary envelope consumed by browser and CLI clients."""
+        self._require_enabled()
+        started = time.perf_counter()
+        data, collectors, database_bytes = await asyncio.gather(
+            self.store.summary(filters),
+            self.store.collector_status(filters),
+            self.store.database_size(),
+        )
+        INSIGHTS_DB_SECONDS.observe(time.perf_counter() - started)
+        return self._envelope(filters, data, collectors, database_bytes)
+
+    async def timeseries(self, filters: QueryFilters, metric: str) -> dict[str, Any]:
+        """Return one accessible chart series and its shared response metadata."""
+        self._require_enabled()
+        if metric not in _SUPPORTED_TIMESERIES:
+            raise ValueError("unsupported timeseries metric")
+        started = time.perf_counter()
+        values, collectors, database_bytes = await asyncio.gather(
+            self.store.timeseries(filters, metric),
+            self.store.collector_status(filters),
+            self.store.database_size(),
+        )
+        INSIGHTS_DB_SECONDS.observe(time.perf_counter() - started)
+        return self._envelope(
+            filters,
+            {"metric": metric, "items": values},
+            collectors,
+            database_bytes,
+        )
+
+    async def activity(
+        self,
+        filters: QueryFilters,
+        *,
+        cursor: str | None,
+        limit: int,
+    ) -> dict[str, Any]:
+        """Return aggregate-only source activity with an opaque next cursor."""
+        self._require_enabled()
+        started = time.perf_counter()
+        (items, next_cursor), collectors, database_bytes = await asyncio.gather(
+            self.store.activity(filters, cursor=cursor, limit=limit),
+            self.store.collector_status(filters),
+            self.store.database_size(),
+        )
+        INSIGHTS_DB_SECONDS.observe(time.perf_counter() - started)
+        return self._envelope(
+            filters,
+            {"items": items, "next_cursor": next_cursor},
+            collectors,
+            database_bytes,
+        )
+
+    async def status(self, filters: QueryFilters) -> dict[str, Any]:
+        """Return collector coverage and the fixed provider capability matrix."""
+        self._require_enabled()
+        collectors, database_bytes = await asyncio.gather(
+            self.store.collector_status(filters),
+            self.store.database_size(),
+        )
+        return self._envelope(
+            filters,
+            {"collectors": collectors},
+            collectors,
+            database_bytes,
+        )
+
+    async def purge(
+        self,
+        box_name: str | None = None,
+        *,
+        instance_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Delete central history without touching any Kubernetes resources."""
+        self._require_enabled()
+        if (box_name is None) == (instance_id is None):
+            raise ValueError("select exactly one devbox or instance_id to purge")
+        if instance_id is not None:
+            _validate_instance_id(instance_id)
+        count = (
+            await self.store.purge_instance(instance_id)
+            if instance_id is not None
+            else await self.store.purge_box(str(box_name))
+        )
+        database_bytes = await self.store.database_size()
+        INSIGHTS_DATABASE_BYTES.set(database_bytes)
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "generated_at": datetime.now(UTC).isoformat(),
+            "enabled": True,
+            "effective_range": None,
+            "coverage": {
+                "status": "purged",
+                "freshness_seconds": None,
+                "collectors": [],
+            },
+            "capabilities": _capabilities(True),
+            "storage": {
+                "database_bytes": database_bytes,
+                "warning_bytes": self.settings.insights_database_warning_bytes,
+                "warning": database_bytes >= self.settings.insights_database_warning_bytes,
+            },
+            "box": box_name or "",
+            "instance_id": instance_id,
+            "purged_instances": count,
+        }
+
+    async def maintain(self) -> dict[str, int]:
+        """Run one enabled-store retention and rollup pass."""
+        self._require_enabled()
+        started = time.perf_counter()
+        result = await self.store.maintain()
+        INSIGHTS_ROLLUP_SECONDS.observe(time.perf_counter() - started)
+        database_bytes = await self.store.database_size()
+        INSIGHTS_DATABASE_BYTES.set(database_bytes)
+        INSIGHTS_LAST_ROLLUP.set_to_current_time()
+        result["database_bytes"] = database_bytes
+        return result
+
+    async def backup(self, destination: str | Path) -> None:
+        """Create an authenticated, transactionally consistent SQLite snapshot."""
+        self._require_enabled()
+        await self.store.backup(destination)
+
+    def filters(
+        self,
+        *,
+        since: str,
+        until: str | None,
+        box: str | None,
+        provider: str | None,
+        model: str | None,
+        repo: str | None,
+        maximum_days: int,
+        instance_id: str | None = None,
+        group_by: str | None = None,
+        bucket: str | None = None,
+    ) -> QueryFilters:
+        """Parse a relative or RFC 3339 range and enforce query cardinality bounds."""
+        end = _parse_timestamp(until) if until else datetime.now(UTC)
+        start = _parse_since(since, end)
+        if start >= end:
+            raise ValueError("since must be earlier than until")
+        if end > datetime.now(UTC) + timedelta(minutes=5):
+            raise ValueError("until cannot be in the future")
+        if end - start > timedelta(days=maximum_days):
+            raise ValueError(f"query range cannot exceed {maximum_days} days")
+        if instance_id is not None:
+            _validate_instance_id(instance_id)
+        if group_by not in {None, "provider", "model", "box", "repository"}:
+            raise ValueError("unsupported Insights grouping")
+        if bucket not in {None, "hour", "day"}:
+            raise ValueError("unsupported Insights bucket")
+        return QueryFilters(
+            since=start,
+            until=end,
+            box=box,
+            instance_id=instance_id,
+            provider=provider,
+            model=model,
+            repo=repo,
+            group_by=group_by,
+            bucket=bucket,
+        )
+
+    def disabled_envelope(self) -> dict[str, Any]:
+        """Describe the safe default state without attempting to open a database."""
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "generated_at": datetime.now(UTC).isoformat(),
+            "enabled": False,
+            "effective_range": None,
+            "coverage": {"status": "disabled", "freshness_seconds": None, "collectors": []},
+            "capabilities": _capabilities(False),
+            "storage": None,
+            "data": None,
+        }
+
+    def _decode_batch(self, body: bytes, content_encoding: str | None) -> dict[str, Any]:
+        if len(body) > self.settings.insights_max_compressed_bytes:
+            raise InsightsPayloadError("compressed batch is too large")
+        encoding = (content_encoding or "identity").strip().lower()
+        if encoding == "gzip":
+            try:
+                with gzip.GzipFile(fileobj=io.BytesIO(body)) as archive:
+                    expanded = archive.read(self.settings.insights_max_expanded_bytes + 1)
+            except (EOFError, OSError) as error:
+                raise InsightsPayloadError("invalid compressed batch") from error
+        elif encoding in {"", "identity"}:
+            expanded = body
+        else:
+            raise InsightsPayloadError("unsupported content encoding")
+        if len(expanded) > self.settings.insights_max_expanded_bytes:
+            raise InsightsPayloadError("expanded batch is too large")
+        try:
+            candidate = json.loads(expanded)
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise InsightsPayloadError("invalid batch JSON") from error
+        if not isinstance(candidate, dict):
+            raise InsightsPayloadError("invalid batch envelope")
+        required = {"schema_version", "batch_id", "sent_at", "collector", "kind", "payload"}
+        allowed = required | {
+            "collector_version",
+            "provider_versions",
+            "last_successful_send_at",
+            "last_error_category",
+            "queue_bytes",
+            "dropped_batches",
+            "dropped_points",
+            "status",
+            "capability_reason",
+        }
+        if not required.issubset(candidate) or not set(candidate).issubset(allowed):
+            raise InsightsPayloadError("invalid batch envelope")
+        if candidate["schema_version"] != SCHEMA_VERSION:
+            raise InsightsPayloadError("unsupported batch schema")
+        if not isinstance(candidate["batch_id"], str) or not _BATCH_ID_RE.fullmatch(
+            candidate["batch_id"]
+        ):
+            raise InsightsPayloadError("invalid batch identifier")
+        if candidate["collector"] not in _COLLECTORS or candidate["kind"] not in _KINDS:
+            raise InsightsPayloadError("invalid collector batch type")
+        expected = {"otlp": "otel", "git": "git", "heartbeat": "agent"}
+        if expected[candidate["kind"]] != candidate["collector"]:
+            raise InsightsPayloadError("invalid collector batch type")
+        sent_at = _parse_timestamp(str(candidate["sent_at"]))
+        if sent_at < datetime(2020, 1, 1, tzinfo=UTC):
+            raise InsightsPayloadError("batch timestamp is outside the accepted range")
+        if sent_at > datetime.now(UTC) + timedelta(minutes=5):
+            raise InsightsPayloadError("batch timestamp is outside the accepted range")
+        return candidate
+
+    def _sanitize_payload(self, kind: str, payload: object) -> tuple[dict[str, Any], int]:
+        if kind == "otlp":
+            return sanitize_otlp(
+                payload,
+                maximum_points=self.settings.insights_max_points_per_batch,
+            )
+        if kind == "git":
+            sanitized = sanitize_git_payload(
+                payload,
+                maximum_commits=self.settings.insights_max_points_per_batch,
+            )
+            return sanitized, sum(len(item["commits"]) for item in sanitized["repositories"])
+        if not isinstance(payload, dict) or set(payload) - {"observed_at"}:
+            raise InsightsPayloadError("invalid heartbeat payload")
+        observed_at = payload.get("observed_at")
+        if observed_at is not None:
+            _parse_timestamp(str(observed_at))
+        return {}, 0
+
+    def _envelope(
+        self,
+        filters: QueryFilters,
+        data: dict[str, Any],
+        collectors: list[dict[str, Any]],
+        database_bytes: int,
+    ) -> dict[str, Any]:
+        freshness = min(
+            (int(item["freshness_seconds"]) for item in collectors),
+            default=None,
+        )
+        if not collectors:
+            coverage_status = "empty"
+        elif any(item["status"] == "stale" for item in collectors):
+            coverage_status = "stale"
+        elif any(
+            item["status"] in {"partial", "restart_required", "data_loss_detected"}
+            or int(item["dropped_points"]) > 0
+            for item in collectors
+        ):
+            coverage_status = "partial"
+        else:
+            coverage_status = "fresh"
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "generated_at": datetime.now(UTC).isoformat(),
+            "enabled": True,
+            "effective_range": {
+                "since": filters.since.isoformat(),
+                "until": filters.until.isoformat(),
+            },
+            "coverage": {
+                "status": coverage_status,
+                "freshness_seconds": freshness,
+                "collectors": collectors,
+            },
+            "capabilities": _capabilities(True),
+            "storage": {
+                "database_bytes": database_bytes,
+                "warning_bytes": self.settings.insights_database_warning_bytes,
+                "warning": database_bytes >= self.settings.insights_database_warning_bytes,
+            },
+            "data": data,
+        }
+
+    def _require_enabled(self) -> None:
+        if not self.enabled:
+            raise InsightsDisabledError
+
+
+def _collector_metadata(batch: dict[str, Any]) -> dict[str, Any]:
+    version = batch.get("collector_version", "1")
+    if not isinstance(version, str) or not re.fullmatch(
+        r"[A-Za-z0-9][A-Za-z0-9_.-]{0,31}", version
+    ):
+        version = "1"
+    queue_bytes = _bounded_nonnegative(batch.get("queue_bytes", 0), 2_147_483_648)
+    dropped_batches = _bounded_nonnegative(batch.get("dropped_batches", 0), 2_147_483_648)
+    dropped_points = _bounded_nonnegative(batch.get("dropped_points", 0), 2_147_483_648)
+    status = batch.get("status", "ok")
+    status = status if status in _SAFE_STATUS else "degraded"
+    reason = batch.get("capability_reason")
+    reason = reason if reason in _SAFE_CAPABILITY_REASONS else None
+    versions = batch.get("provider_versions")
+    provider_versions = (
+        {
+            key: value
+            for key, value in versions.items()
+            if key in {"codex", "claude"}
+            and isinstance(value, str)
+            and re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", value)
+        }
+        if isinstance(versions, dict)
+        else {}
+    )
+    last_successful_send_at = batch.get("last_successful_send_at")
+    if last_successful_send_at is not None:
+        try:
+            last_successful_send_at = _parse_timestamp(str(last_successful_send_at)).isoformat()
+        except InsightsPayloadError:
+            last_successful_send_at = None
+    last_error_category = batch.get("last_error_category")
+    if last_error_category not in _SAFE_ERROR_CATEGORIES:
+        last_error_category = None
+    return {
+        "collector_version": version,
+        "provider_versions": provider_versions,
+        "last_successful_send_at": last_successful_send_at,
+        "last_error_category": last_error_category,
+        "queue_bytes": queue_bytes,
+        "dropped_batches": dropped_batches,
+        "dropped_points": dropped_points,
+        "status": status,
+        "capability_reason": reason,
+    }
+
+
+def _bounded_nonnegative(value: object, maximum: int) -> int:
+    if isinstance(value, int) and not isinstance(value, bool) and 0 <= value <= maximum:
+        return value
+    return 0
+
+
+def _parse_since(value: str, end: datetime) -> datetime:
+    match = re.fullmatch(r"([1-9][0-9]{0,3})([hd])", value.strip())
+    if match:
+        amount = int(match.group(1))
+        delta = timedelta(hours=amount) if match.group(2) == "h" else timedelta(days=amount)
+        return end - delta
+    return _parse_timestamp(value)
+
+
+def _parse_timestamp(value: str | None) -> datetime:
+    if value is None or len(value) > 64:
+        raise InsightsPayloadError("invalid timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise InsightsPayloadError("invalid timestamp") from error
+    if parsed.tzinfo is None:
+        raise InsightsPayloadError("timestamp must include a timezone")
+    return parsed.astimezone(UTC)
+
+
+def _safe_provider(provider: str) -> str:
+    return provider if provider in {"codex", "claude", "git"} else "unknown"
+
+
+def _validate_instance_id(value: str) -> None:
+    try:
+        parsed = uuid.UUID(value)
+    except ValueError as error:
+        raise ValueError("instance_id must be a UUID") from error
+    if parsed.version != 4 or str(parsed) != value:
+        raise ValueError("instance_id must be a canonical UUIDv4")
+
+
+def record_insights_rejection(reason: str) -> None:
+    """Increment one bounded operational error category without request dimensions."""
+    safe_reason = (
+        reason
+        if reason in {"authentication", "media_type", "size", "rate_limit", "storage", "validation"}
+        else "validation"
+    )
+    INSIGHTS_INGEST_RESULTS.labels(result="rejected").inc()
+    INSIGHTS_INGEST_ERRORS.labels(reason=safe_reason).inc()
+
+
+def _capabilities(enabled: bool) -> dict[str, Any]:
+    disabled_reason = None if enabled else "Insights is disabled by the operator"
+    return {
+        "codex": {
+            "version": "0.144.0",
+            "sessions": {
+                "supported": enabled,
+                "reason": disabled_reason or "Counted from process starts",
+            },
+            "tokens": {"supported": enabled, "reason": disabled_reason},
+            "cost": {
+                "supported": False,
+                "reason": "Not reported by Codex 0.144.0",
+            },
+            "active_time": {
+                "supported": False,
+                "reason": "Not reported by Codex 0.144.0",
+            },
+            "ai_lines": {
+                "supported": False,
+                "reason": "Not reported by Codex 0.144.0",
+            },
+        },
+        "claude": {
+            "version": "2.1.205",
+            "sessions": {"supported": enabled, "reason": disabled_reason},
+            "tokens": {"supported": enabled, "reason": disabled_reason},
+            "cost": {
+                "supported": enabled,
+                "reason": disabled_reason or "Provider-reported estimate",
+            },
+            "active_time": {"supported": enabled, "reason": disabled_reason},
+            "ai_lines": {"supported": enabled, "reason": disabled_reason},
+        },
+        "git": {
+            "commits": {"supported": enabled, "reason": disabled_reason},
+            "churn": {"supported": enabled, "reason": disabled_reason},
+            "working_tree": {"supported": enabled, "reason": disabled_reason},
+            "limitations": [
+                "First scan establishes a baseline and does not import repository history",
+                "Rewritten or deleted commits that are never observed cannot be counted",
+                "Binary changes count files but not line churn",
+            ],
+        },
+    }

--- a/controller/src/devboxes_controller/insights_store.py
+++ b/controller/src/devboxes_controller/insights_store.py
@@ -1,0 +1,1446 @@
+"""Provide the bounded, migration-backed SQLite store for Devboxes Insights."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import json
+import sqlite3
+from collections.abc import Iterable
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Final
+
+SCHEMA_VERSION: Final = 1
+_MINIMUM_TIMESTAMP = datetime(2020, 1, 1, tzinfo=UTC)
+
+
+@dataclass(frozen=True)
+class IngestResult:
+    """Report the transaction result for one authenticated collector batch."""
+
+    accepted: bool
+    duplicate: bool
+    points: int
+    providers: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class QueryFilters:
+    """Hold one validated Insights query range and its optional dimensions."""
+
+    since: datetime
+    until: datetime
+    box: str | None = None
+    instance_id: str | None = None
+    provider: str | None = None
+    model: str | None = None
+    repo: str | None = None
+    group_by: str | None = None
+    bucket: str | None = None
+
+
+class InsightsStore:
+    """Serialize writes while allowing short independent SQLite read connections."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        raw_days: int = 30,
+        hourly_days: int = 90,
+        daily_days: int = 365,
+    ) -> None:
+        self.path = Path(path)
+        self.raw_days = raw_days
+        self.hourly_days = hourly_days
+        self.daily_days = daily_days
+        self._writer_lock = asyncio.Lock()
+
+    async def initialize(self) -> None:
+        """Create the database and apply every migration transactionally."""
+        async with self._writer_lock:
+            await asyncio.to_thread(self._initialize_sync)
+
+    async def ready(self) -> bool:
+        """Return whether the Insights schema is readable and current."""
+        try:
+            return await asyncio.to_thread(self._ready_sync)
+        except (OSError, sqlite3.Error):
+            return False
+
+    async def ingest(
+        self,
+        *,
+        instance_id: str,
+        box_name: str,
+        batch_id: str,
+        collector: str,
+        kind: str,
+        sent_at: datetime,
+        payload: dict[str, Any],
+        reported_points: int,
+    ) -> IngestResult:
+        """Persist one idempotent metrics, Git, or heartbeat batch."""
+        async with self._writer_lock:
+            return await asyncio.to_thread(
+                self._ingest_sync,
+                instance_id,
+                box_name,
+                batch_id,
+                collector,
+                kind,
+                sent_at,
+                payload,
+                reported_points,
+            )
+
+    async def summary(self, filters: QueryFilters) -> dict[str, Any]:
+        """Aggregate AI and source-control data without conflating their meanings."""
+        return await asyncio.to_thread(self._summary_sync, filters)
+
+    async def timeseries(self, filters: QueryFilters, metric: str) -> list[dict[str, Any]]:
+        """Return a bounded hourly or daily series for one supported dashboard metric."""
+        return await asyncio.to_thread(self._timeseries_sync, filters, metric)
+
+    async def activity(
+        self,
+        filters: QueryFilters,
+        *,
+        cursor: str | None,
+        limit: int,
+    ) -> tuple[list[dict[str, Any]], str | None]:
+        """Return cursor-paginated, aggregate-only Git activity."""
+        return await asyncio.to_thread(self._activity_sync, filters, cursor, limit)
+
+    async def collector_status(self, filters: QueryFilters) -> list[dict[str, Any]]:
+        """Return collector freshness and loss counters for coverage reporting."""
+        return await asyncio.to_thread(self._collector_status_sync, filters)
+
+    async def purge_box(self, box_name: str) -> int:
+        """Delete central Insights records for every instance that used a box name."""
+        async with self._writer_lock:
+            return await asyncio.to_thread(self._purge_box_sync, box_name)
+
+    async def purge_instance(self, instance_id: str) -> int:
+        """Delete central Insights records for one stable workspace instance."""
+        async with self._writer_lock:
+            return await asyncio.to_thread(self._purge_instance_sync, instance_id)
+
+    async def maintain(self) -> dict[str, int]:
+        """Materialize rollups, enforce retention, and checkpoint the WAL."""
+        async with self._writer_lock:
+            return await asyncio.to_thread(self._maintain_sync)
+
+    async def backup(self, destination: str | Path) -> None:
+        """Create a consistent live snapshot through SQLite's online backup API."""
+        async with self._writer_lock:
+            await asyncio.to_thread(self._backup_sync, Path(destination))
+
+    async def database_size(self) -> int:
+        """Return the current SQLite main, WAL, and shared-memory footprint."""
+        return await asyncio.to_thread(self._database_size_sync)
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.path, timeout=5, isolation_level=None)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys=ON")
+        connection.execute("PRAGMA busy_timeout=5000")
+        connection.execute("PRAGMA synchronous=FULL")
+        return connection
+
+    def _initialize_sync(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        connection = self._connect()
+        try:
+            connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA synchronous=FULL")
+            connection.executescript(f"BEGIN IMMEDIATE;\n{_SCHEMA}\nCOMMIT;")
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    def _ready_sync(self) -> bool:
+        connection = self._connect()
+        try:
+            row = connection.execute(
+                "SELECT MAX(version) AS version FROM schema_migrations"
+            ).fetchone()
+            connection.execute("SELECT 1 FROM metric_points LIMIT 1").fetchone()
+            return row is not None and row["version"] == SCHEMA_VERSION
+        finally:
+            connection.close()
+
+    def _ingest_sync(
+        self,
+        instance_id: str,
+        box_name: str,
+        batch_id: str,
+        collector: str,
+        kind: str,
+        sent_at: datetime,
+        payload: dict[str, Any],
+        reported_points: int,
+    ) -> IngestResult:
+        connection = self._connect()
+        providers: set[str] = set()
+        inserted_points = 0
+        received_at = _now_text()
+        observation_payload = {
+            key: value
+            for key, value in payload.items()
+            if key
+            not in {
+                "collector_version",
+                "provider_versions",
+                "last_successful_send_at",
+                "last_error_category",
+                "queue_bytes",
+                "dropped_batches",
+                "dropped_points",
+                "status",
+                "capability_reason",
+            }
+        }
+        fingerprint = hashlib.sha256(
+            _canonical({"kind": kind, "payload": observation_payload}).encode()
+        ).hexdigest()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            duplicate = connection.execute(
+                "SELECT instance_id, fingerprint FROM ingest_batches WHERE batch_id = ?",
+                (batch_id,),
+            ).fetchone()
+            if duplicate is not None:
+                if (
+                    duplicate["instance_id"] != instance_id
+                    or duplicate["fingerprint"] != fingerprint
+                ):
+                    raise ValueError("batch identifier conflicts with an existing batch")
+                connection.rollback()
+                return IngestResult(False, True, 0, ())
+            connection.execute(
+                """
+                INSERT INTO devbox_instances(id, name, first_seen_at, last_seen_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    name=excluded.name, last_seen_at=excluded.last_seen_at,
+                    deleted_at=NULL
+                """,
+                (instance_id, box_name, received_at, received_at),
+            )
+            if kind == "otlp":
+                inserted_points, providers = self._insert_otlp(
+                    connection, instance_id, batch_id, payload
+                )
+            elif kind == "git":
+                self._insert_git(connection, instance_id, batch_id, payload, sent_at)
+            elif kind != "heartbeat":
+                raise ValueError("unsupported collector batch kind")
+
+            queue_bytes = _safe_int(payload.get("queue_bytes"), default=0)
+            dropped = _safe_int(payload.get("dropped_points"), default=0)
+            dropped_batches = _safe_int(payload.get("dropped_batches"), default=0)
+            status = str(payload.get("status", "ok"))[:32]
+            reason = payload.get("capability_reason")
+            capability_reason = str(reason)[:240] if reason else None
+            provider_versions = payload.get("provider_versions", {})
+            last_successful_send_at = payload.get("last_successful_send_at")
+            last_error_category = payload.get("last_error_category")
+            connection.execute(
+                """
+                INSERT INTO collectors(instance_id, kind, version, status, capability_reason,
+                    last_seen_at, queue_bytes, dropped_batches, dropped_points,
+                    provider_versions_json, last_successful_send_at, last_error_category)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(instance_id, kind) DO UPDATE SET
+                    version=excluded.version, status=excluded.status,
+                    capability_reason=excluded.capability_reason,
+                    last_seen_at=excluded.last_seen_at, queue_bytes=excluded.queue_bytes,
+                    dropped_batches=excluded.dropped_batches,
+                    dropped_points=excluded.dropped_points,
+                    provider_versions_json=excluded.provider_versions_json,
+                    last_successful_send_at=excluded.last_successful_send_at,
+                    last_error_category=excluded.last_error_category
+                """,
+                (
+                    instance_id,
+                    collector,
+                    str(payload.get("collector_version", "1"))[:32],
+                    status,
+                    capability_reason,
+                    received_at,
+                    queue_bytes,
+                    dropped_batches,
+                    dropped,
+                    _canonical(provider_versions),
+                    last_successful_send_at,
+                    last_error_category,
+                ),
+            )
+            connection.execute(
+                """
+                INSERT INTO ingest_batches(batch_id, instance_id, received_at, sent_at, collector,
+                    kind, point_count, fingerprint)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    batch_id,
+                    instance_id,
+                    received_at,
+                    sent_at.isoformat(),
+                    collector,
+                    kind,
+                    inserted_points if kind == "otlp" else reported_points,
+                    fingerprint,
+                ),
+            )
+            connection.commit()
+            return IngestResult(True, False, inserted_points, tuple(sorted(providers)))
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    def _insert_otlp(
+        self,
+        connection: sqlite3.Connection,
+        instance_id: str,
+        batch_id: str,
+        payload: dict[str, Any],
+    ) -> tuple[int, set[str]]:
+        now = datetime.now(UTC)
+        inserted = 0
+        providers: set[str] = set()
+        for resource_metric in payload["resourceMetrics"]:
+            resource_attributes = _attribute_dict(
+                resource_metric.get("resource", {}).get("attributes", [])
+            )
+            resource_service = str(resource_attributes.get("service.name", ""))
+            for scope_metric in resource_metric["scopeMetrics"]:
+                for metric in scope_metric["metrics"]:
+                    metric_name = str(metric["name"])
+                    provider = _provider(metric_name, resource_service)
+                    providers.add(provider)
+                    unit = str(metric.get("unit", ""))
+                    for form in (
+                        "gauge",
+                        "sum",
+                        "histogram",
+                        "exponentialHistogram",
+                        "summary",
+                    ):
+                        data = metric.get(form)
+                        if not isinstance(data, dict):
+                            continue
+                        temporality = _temporality(data.get("aggregationTemporality"))
+                        monotonic = bool(data.get("isMonotonic", False))
+                        for point in data["dataPoints"]:
+                            attributes = _attribute_dict(point.get("attributes", []))
+                            model = attributes.get("model")
+                            series_attributes = {
+                                key: value
+                                for key, value in attributes.items()
+                                if key not in {"provider", "model"}
+                            }
+                            observed_at = _point_time(point, "timeUnixNano", now)
+                            start_at = _optional_point_time(point, "startTimeUnixNano", now)
+                            raw_value = _point_value(point)
+                            series_hash = hashlib.sha256(
+                                _canonical(
+                                    {
+                                        "instance": instance_id,
+                                        "metric": metric_name,
+                                        "provider": provider,
+                                        "model": model,
+                                        "unit": unit,
+                                        "form": form,
+                                        "temporality": temporality,
+                                        "monotonic": monotonic,
+                                        "attributes": series_attributes,
+                                    }
+                                ).encode()
+                            ).hexdigest()
+                            connection.execute(
+                                """
+                                INSERT OR IGNORE INTO metric_series(instance_id, metric_name,
+                                    provider, model, unit, form, temporality, monotonic,
+                                    attributes_json, series_hash)
+                                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                """,
+                                (
+                                    instance_id,
+                                    metric_name,
+                                    provider,
+                                    model,
+                                    unit,
+                                    form,
+                                    temporality,
+                                    monotonic,
+                                    _canonical(series_attributes),
+                                    series_hash,
+                                ),
+                            )
+                            series_row = connection.execute(
+                                "SELECT id FROM metric_series WHERE series_hash = ?",
+                                (series_hash,),
+                            ).fetchone()
+                            if series_row is None:
+                                raise sqlite3.IntegrityError("metric series was not created")
+                            series_id = int(series_row["id"])
+                            effective_value = self._effective_value(
+                                connection,
+                                series_id,
+                                temporality,
+                                monotonic,
+                                raw_value,
+                                start_at,
+                            )
+                            point_payload = {
+                                key: value for key, value in point.items() if key != "attributes"
+                            }
+                            point_fingerprint = hashlib.sha256(
+                                _canonical(
+                                    {
+                                        "series": series_hash,
+                                        "observed_at": observed_at,
+                                        "start_at": start_at,
+                                        "point": point_payload,
+                                    }
+                                ).encode()
+                            ).hexdigest()
+                            cursor = connection.execute(
+                                """
+                                INSERT OR IGNORE INTO metric_points(series_id, batch_id,
+                                    observed_at, start_at, value, raw_value, payload_json,
+                                    fingerprint)
+                                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                                """,
+                                (
+                                    series_id,
+                                    batch_id,
+                                    observed_at,
+                                    start_at,
+                                    effective_value,
+                                    raw_value,
+                                    _canonical(point_payload),
+                                    point_fingerprint,
+                                ),
+                            )
+                            inserted += max(cursor.rowcount, 0)
+        return inserted, providers
+
+    @staticmethod
+    def _effective_value(
+        connection: sqlite3.Connection,
+        series_id: int,
+        temporality: str,
+        monotonic: bool,
+        raw_value: float,
+        start_at: str | None,
+    ) -> float:
+        if temporality != "cumulative" or not monotonic:
+            return raw_value
+        previous = connection.execute(
+            """
+            SELECT raw_value, start_at FROM metric_points
+            WHERE series_id = ? ORDER BY observed_at DESC, id DESC LIMIT 1
+            """,
+            (series_id,),
+        ).fetchone()
+        if previous is None:
+            return raw_value
+        if previous["start_at"] != start_at or raw_value < float(previous["raw_value"]):
+            return raw_value
+        return raw_value - float(previous["raw_value"])
+
+    @staticmethod
+    def _insert_git(
+        connection: sqlite3.Connection,
+        instance_id: str,
+        batch_id: str,
+        payload: dict[str, Any],
+        sent_at: datetime,
+    ) -> None:
+        for repository in payload["repositories"]:
+            repo_key = str(repository["repo_key"])
+            connection.execute(
+                """
+                INSERT INTO repositories(instance_id, repo_key, first_seen_at, last_seen_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(instance_id, repo_key) DO UPDATE SET last_seen_at=excluded.last_seen_at
+                """,
+                (instance_id, repo_key, sent_at.isoformat(), sent_at.isoformat()),
+            )
+            repo_row = connection.execute(
+                "SELECT id FROM repositories WHERE instance_id = ? AND repo_key = ?",
+                (instance_id, repo_key),
+            ).fetchone()
+            if repo_row is None:
+                raise sqlite3.IntegrityError("repository was not created")
+            repo_id = int(repo_row["id"])
+            for commit in repository["commits"]:
+                connection.execute(
+                    """
+                    INSERT OR IGNORE INTO code_commits(instance_id, repository_id, batch_id, sha,
+                        committed_at, additions, deletions, files_changed, binary_files, is_merge)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        instance_id,
+                        repo_id,
+                        batch_id,
+                        commit["sha"],
+                        commit["committed_at"],
+                        commit["additions"],
+                        commit["deletions"],
+                        commit["files_changed"],
+                        commit["binary_files"],
+                        int(commit["is_merge"]),
+                    ),
+                )
+            tree = repository.get("working_tree")
+            if tree is not None:
+                fingerprint = hashlib.sha256(
+                    _canonical({"repo": repo_key, "tree": tree, "at": sent_at.isoformat()}).encode()
+                ).hexdigest()
+                connection.execute(
+                    """
+                    INSERT OR IGNORE INTO working_tree_snapshots(instance_id, repository_id,
+                        batch_id, observed_at, staged_additions, staged_deletions, staged_files,
+                        unstaged_additions, unstaged_deletions, unstaged_files, binary_files,
+                        fingerprint)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        instance_id,
+                        repo_id,
+                        batch_id,
+                        sent_at.isoformat(),
+                        tree["staged_additions"],
+                        tree["staged_deletions"],
+                        tree["staged_files"],
+                        tree["unstaged_additions"],
+                        tree["unstaged_deletions"],
+                        tree["unstaged_files"],
+                        tree["binary_files"],
+                        fingerprint,
+                    ),
+                )
+
+    def _summary_sync(self, filters: QueryFilters) -> dict[str, Any]:
+        result = self._summary_core(filters)
+        if filters.group_by:
+            result["group_by"] = filters.group_by
+            result["groups"] = self._summary_groups(filters, result)
+        return result
+
+    def _summary_core(self, filters: QueryFilters) -> dict[str, Any]:
+        connection = self._connect()
+        try:
+            source, source_parameters = self._metric_source(filters)
+            metric_where, metric_parameters = _metric_dimension_filter(filters)
+            metric_rows = connection.execute(
+                f"""
+                WITH metric_values AS ({source})
+                SELECT s.metric_name, s.provider, s.model, s.attributes_json,
+                    SUM(v.value) AS value
+                FROM metric_values v
+                JOIN metric_series s ON s.id = v.series_id
+                JOIN devbox_instances i ON i.id = s.instance_id
+                WHERE {metric_where}
+                GROUP BY s.metric_name, s.provider, s.model, s.attributes_json
+                """,
+                [*source_parameters, *metric_parameters],
+            ).fetchall()
+            ai = _summarize_ai(metric_rows)
+            git_where, git_parameters = _git_filter(filters)
+            git_row = connection.execute(
+                f"""
+                SELECT COUNT(*) AS commits, COALESCE(SUM(c.additions), 0) AS additions,
+                    COALESCE(SUM(c.deletions), 0) AS deletions,
+                    COALESCE(SUM(c.files_changed), 0) AS files_changed,
+                    COALESCE(SUM(c.binary_files), 0) AS binary_files
+                FROM code_commits c
+                JOIN repositories r ON r.id = c.repository_id
+                JOIN devbox_instances i ON i.id = c.instance_id
+                WHERE {git_where}
+                """,
+                git_parameters,
+            ).fetchone()
+            worktree = self._latest_worktree(connection, filters)
+            return {
+                "ai": ai,
+                "code": {
+                    "commits": int(git_row["commits"] if git_row else 0),
+                    "additions": int(git_row["additions"] if git_row else 0),
+                    "deletions": int(git_row["deletions"] if git_row else 0),
+                    "files_changed": int(git_row["files_changed"] if git_row else 0),
+                    "binary_files": int(git_row["binary_files"] if git_row else 0),
+                    "working_tree": worktree,
+                },
+            }
+        finally:
+            connection.close()
+
+    def _summary_groups(
+        self,
+        filters: QueryFilters,
+        summary: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        if filters.group_by == "provider":
+            return [
+                {"key": key, "ai": value, "code": None}
+                for key, value in sorted(summary["ai"]["providers"].items())
+            ]
+
+        group_by = filters.group_by
+        if group_by is None:
+            return []
+        key_field = {
+            "box": "box",
+            "model": "model",
+            "repository": "repo",
+        }.get(group_by)
+        if key_field is None:
+            return []
+        groups: list[dict[str, Any]] = []
+        for key in self._group_keys(filters, key_field):
+            if key_field == "box":
+                grouped_filters = replace(filters, group_by=None, box=key)
+            elif key_field == "model":
+                grouped_filters = replace(filters, group_by=None, model=key)
+            else:
+                grouped_filters = replace(filters, group_by=None, repo=key)
+            grouped = self._summary_core(grouped_filters)
+            if not _summary_has_data(grouped):
+                continue
+            groups.append({"key": key, **grouped})
+        return groups
+
+    def _group_keys(self, filters: QueryFilters, field: str) -> list[str]:
+        connection = self._connect()
+        try:
+            if field == "box":
+                conditions = ["1=1"]
+                parameters: list[Any] = []
+                if filters.instance_id:
+                    conditions.append("id = ?")
+                    parameters.append(filters.instance_id)
+                if filters.box:
+                    conditions.append("name = ?")
+                    parameters.append(filters.box)
+                rows = connection.execute(
+                    f"SELECT DISTINCT name AS value FROM devbox_instances "
+                    f"WHERE {' AND '.join(conditions)} ORDER BY value LIMIT 200",
+                    parameters,
+                ).fetchall()
+            elif field == "model":
+                conditions = ["model IS NOT NULL"]
+                parameters = []
+                if filters.provider:
+                    conditions.append("provider = ?")
+                    parameters.append(filters.provider)
+                if filters.model:
+                    conditions.append("model = ?")
+                    parameters.append(filters.model)
+                if filters.instance_id:
+                    conditions.append("instance_id = ?")
+                    parameters.append(filters.instance_id)
+                rows = connection.execute(
+                    f"SELECT DISTINCT model AS value FROM metric_series "
+                    f"WHERE {' AND '.join(conditions)} ORDER BY value LIMIT 200",
+                    parameters,
+                ).fetchall()
+            else:
+                conditions = ["1=1"]
+                parameters = []
+                if filters.repo:
+                    conditions.append("repo_key = ?")
+                    parameters.append(filters.repo)
+                if filters.instance_id:
+                    conditions.append("instance_id = ?")
+                    parameters.append(filters.instance_id)
+                rows = connection.execute(
+                    f"SELECT DISTINCT repo_key AS value FROM repositories "
+                    f"WHERE {' AND '.join(conditions)} ORDER BY value LIMIT 200",
+                    parameters,
+                ).fetchall()
+            return [str(row["value"]) for row in rows]
+        finally:
+            connection.close()
+
+    def _latest_worktree(
+        self, connection: sqlite3.Connection, filters: QueryFilters
+    ) -> dict[str, int]:
+        conditions = ["1=1"]
+        parameters: list[Any] = []
+        if filters.box:
+            conditions.append("i.name = ?")
+            parameters.append(filters.box)
+        if filters.instance_id:
+            conditions.append("i.id = ?")
+            parameters.append(filters.instance_id)
+        if filters.repo:
+            conditions.append("r.repo_key = ?")
+            parameters.append(filters.repo)
+        rows = connection.execute(
+            f"""
+            SELECT w.* FROM working_tree_snapshots w
+            JOIN repositories r ON r.id = w.repository_id
+            JOIN devbox_instances i ON i.id = w.instance_id
+            WHERE {" AND ".join(conditions)}
+              AND w.id = (SELECT w2.id FROM working_tree_snapshots w2
+                WHERE w2.repository_id = w.repository_id
+                ORDER BY w2.observed_at DESC, w2.id DESC LIMIT 1)
+            """,
+            parameters,
+        ).fetchall()
+        keys = (
+            "staged_additions",
+            "staged_deletions",
+            "staged_files",
+            "unstaged_additions",
+            "unstaged_deletions",
+            "unstaged_files",
+            "binary_files",
+        )
+        return {key: sum(int(row[key]) for row in rows) for key in keys}
+
+    def _timeseries_sync(self, filters: QueryFilters, metric: str) -> list[dict[str, Any]]:
+        connection = self._connect()
+        try:
+            days = (filters.until - filters.since).total_seconds() / 86_400
+            hourly = filters.bucket == "hour" or (filters.bucket is None and days <= 3)
+            if metric in {"git_commits", "git_churn"}:
+                git_bucket = (
+                    "strftime('%Y-%m-%dT%H:00:00Z', c.committed_at)"
+                    if hourly
+                    else "strftime('%Y-%m-%dT00:00:00Z', c.committed_at)"
+                )
+                git_where, parameters = _git_filter(filters)
+                expression = (
+                    "COUNT(*)" if metric == "git_commits" else "SUM(c.additions+c.deletions)"
+                )
+                rows = connection.execute(
+                    f"""
+                    SELECT {git_bucket} AS bucket, 'git' AS provider,
+                        COALESCE({expression}, 0) AS value
+                    FROM code_commits c
+                    JOIN repositories r ON r.id = c.repository_id
+                    JOIN devbox_instances i ON i.id = c.instance_id
+                    WHERE {git_where}
+                    GROUP BY bucket ORDER BY bucket
+                    """,
+                    parameters,
+                ).fetchall()
+                return [dict(row) for row in rows]
+
+            metric_names = {
+                "sessions": ("claude_code.session.count", "codex.process.start"),
+                "tokens": ("claude_code.token.usage", "codex.turn.token_usage"),
+                "cost": ("claude_code.cost.usage",),
+                "active_time": ("claude_code.active_time.total",),
+                "ai_lines": ("claude_code.lines_of_code.count",),
+            }[metric]
+            placeholders = ",".join("?" for _ in metric_names)
+            source, source_parameters = self._metric_source(filters)
+            metric_where, metric_parameters = _metric_dimension_filter(filters)
+            bucket_expression = (
+                "strftime('%Y-%m-%dT%H:00:00Z', v.observed_at)"
+                if hourly
+                else "strftime('%Y-%m-%dT00:00:00Z', v.observed_at)"
+            )
+            rows = connection.execute(
+                f"""
+                WITH metric_values AS ({source})
+                SELECT {bucket_expression} AS bucket, s.provider, s.metric_name,
+                    s.attributes_json, SUM(v.value) AS value
+                FROM metric_values v
+                JOIN metric_series s ON s.id = v.series_id
+                JOIN devbox_instances i ON i.id = s.instance_id
+                WHERE {metric_where} AND s.metric_name IN ({placeholders})
+                GROUP BY bucket, s.provider, s.metric_name, s.attributes_json
+                ORDER BY bucket
+                """,
+                [*source_parameters, *metric_parameters, *metric_names],
+            ).fetchall()
+            return _normalize_series(rows, metric)
+        finally:
+            connection.close()
+
+    def _metric_source(self, filters: QueryFilters) -> tuple[str, list[Any]]:
+        now = datetime.now(UTC)
+        raw_boundary = (now - timedelta(days=self.raw_days)).replace(
+            minute=0, second=0, microsecond=0
+        )
+        hourly_boundary = (now - timedelta(days=self.hourly_days)).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        daily_boundary = (now - timedelta(days=self.daily_days)).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        sources = [
+            "SELECT series_id, observed_at, value FROM metric_points "
+            "WHERE observed_at >= ? AND observed_at <= ?"
+        ]
+        parameters: list[Any] = [filters.since.isoformat(), filters.until.isoformat()]
+
+        hourly_start = max(filters.since, hourly_boundary)
+        hourly_end = min(filters.until + timedelta(microseconds=1), raw_boundary)
+        if hourly_start < hourly_end:
+            sources.append(
+                "SELECT series_id, bucket_start AS observed_at, value "
+                "FROM metric_rollups_hourly WHERE bucket_start >= ? AND bucket_start < ?"
+            )
+            parameters.extend((hourly_start.isoformat(), hourly_end.isoformat()))
+
+        daily_start = max(filters.since, daily_boundary)
+        daily_end = min(filters.until + timedelta(microseconds=1), hourly_boundary)
+        if daily_start < daily_end:
+            sources.append(
+                "SELECT series_id, bucket_start AS observed_at, value "
+                "FROM metric_rollups_daily WHERE bucket_start >= ? AND bucket_start < ?"
+            )
+            parameters.extend((daily_start.isoformat(), daily_end.isoformat()))
+        return " UNION ALL ".join(sources), parameters
+
+    def _activity_sync(
+        self,
+        filters: QueryFilters,
+        cursor: str | None,
+        limit: int,
+    ) -> tuple[list[dict[str, Any]], str | None]:
+        connection = self._connect()
+        try:
+            where, parameters = _git_filter(filters)
+            cursor_id = _decode_cursor(cursor)
+            if cursor_id is not None:
+                where += " AND c.id < ?"
+                parameters.append(cursor_id)
+            rows = connection.execute(
+                f"""
+                SELECT c.id, i.name AS box, r.repo_key AS repo, c.committed_at,
+                    c.additions, c.deletions, c.files_changed, c.binary_files, c.is_merge
+                FROM code_commits c
+                JOIN repositories r ON r.id = c.repository_id
+                JOIN devbox_instances i ON i.id = c.instance_id
+                WHERE {where}
+                ORDER BY c.id DESC LIMIT ?
+                """,
+                [*parameters, limit + 1],
+            ).fetchall()
+            has_more = len(rows) > limit
+            selected = rows[:limit]
+            items = [
+                {
+                    "id": int(row["id"]),
+                    "type": "git_commit",
+                    "box": row["box"],
+                    "repo": row["repo"],
+                    "observed_at": row["committed_at"],
+                    "additions": int(row["additions"]),
+                    "deletions": int(row["deletions"]),
+                    "files_changed": int(row["files_changed"]),
+                    "binary_files": int(row["binary_files"]),
+                    "is_merge": bool(row["is_merge"]),
+                }
+                for row in selected
+            ]
+            next_cursor = _encode_cursor(int(selected[-1]["id"])) if has_more and selected else None
+            return items, next_cursor
+        finally:
+            connection.close()
+
+    def _collector_status_sync(self, filters: QueryFilters) -> list[dict[str, Any]]:
+        connection = self._connect()
+        try:
+            conditions = ["1=1"]
+            parameters: list[Any] = []
+            if filters.box:
+                conditions.append("i.name = ?")
+                parameters.append(filters.box)
+            if filters.instance_id:
+                conditions.append("i.id = ?")
+                parameters.append(filters.instance_id)
+            rows = connection.execute(
+                f"""
+                SELECT i.name AS box, c.kind, c.version, c.status, c.capability_reason,
+                    c.last_seen_at, c.queue_bytes, c.dropped_batches, c.dropped_points,
+                    c.provider_versions_json, c.last_successful_send_at,
+                    c.last_error_category
+                FROM collectors c JOIN devbox_instances i ON i.id = c.instance_id
+                WHERE {" AND ".join(conditions)} ORDER BY i.name, c.kind
+                """,
+                parameters,
+            ).fetchall()
+            now = datetime.now(UTC)
+            result: list[dict[str, Any]] = []
+            for row in rows:
+                last_seen = _parse_datetime(str(row["last_seen_at"]))
+                freshness = max(0, int((now - last_seen).total_seconds()))
+                if freshness > 180:
+                    collector_state = "stale"
+                elif int(row["dropped_points"]) > 0:
+                    collector_state = "data_loss_detected"
+                elif row["status"] == "degraded":
+                    collector_state = "partial"
+                else:
+                    collector_state = "healthy"
+                result.append(
+                    {
+                        "box": row["box"],
+                        "collector": row["kind"],
+                        "version": row["version"],
+                        "status": collector_state,
+                        "capability_reason": row["capability_reason"],
+                        "last_seen_at": row["last_seen_at"],
+                        "freshness_seconds": freshness,
+                        "queue_bytes": int(row["queue_bytes"]),
+                        "dropped_batches": int(row["dropped_batches"]),
+                        "dropped_points": int(row["dropped_points"]),
+                        "provider_versions": json.loads(row["provider_versions_json"]),
+                        "last_successful_send_at": row["last_successful_send_at"],
+                        "last_error_category": row["last_error_category"],
+                    }
+                )
+            return result
+        finally:
+            connection.close()
+
+    def _purge_box_sync(self, box_name: str) -> int:
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            identifiers = connection.execute(
+                "SELECT id FROM devbox_instances WHERE name = ?", (box_name,)
+            ).fetchall()
+            connection.execute("DELETE FROM devbox_instances WHERE name = ?", (box_name,))
+            connection.commit()
+            return len(identifiers)
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    def _purge_instance_sync(self, instance_id: str) -> int:
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            deleted = connection.execute(
+                "DELETE FROM devbox_instances WHERE id = ?", (instance_id,)
+            ).rowcount
+            connection.commit()
+            return max(deleted, 0)
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    def _maintain_sync(self) -> dict[str, int]:
+        now = datetime.now(UTC)
+        raw_cutoff = (
+            (now - timedelta(days=self.raw_days))
+            .replace(minute=0, second=0, microsecond=0)
+            .isoformat()
+        )
+        hourly_cutoff = (
+            (now - timedelta(days=self.hourly_days))
+            .replace(hour=0, minute=0, second=0, microsecond=0)
+            .isoformat()
+        )
+        daily_cutoff = (
+            (now - timedelta(days=self.daily_days))
+            .replace(hour=0, minute=0, second=0, microsecond=0)
+            .isoformat()
+        )
+        connection = self._connect()
+        deleted = {"raw_points": 0, "hourly_rollups": 0, "daily_rollups": 0}
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            connection.execute(
+                """
+                INSERT INTO metric_rollups_hourly(series_id, bucket_start, value, sample_count,
+                    minimum, maximum)
+                SELECT series_id, strftime('%Y-%m-%dT%H:00:00Z', observed_at), SUM(value),
+                    COUNT(*), MIN(value), MAX(value)
+                FROM metric_points
+                WHERE observed_at >= ?
+                GROUP BY series_id, 2
+                ON CONFLICT(series_id, bucket_start) DO UPDATE SET
+                    value=excluded.value,
+                    sample_count=excluded.sample_count,
+                    minimum=excluded.minimum,
+                    maximum=excluded.maximum
+                """,
+                (daily_cutoff,),
+            )
+            connection.execute(
+                """
+                INSERT INTO metric_rollups_daily(series_id, bucket_start, value, sample_count,
+                    minimum, maximum)
+                SELECT series_id, strftime('%Y-%m-%dT00:00:00Z', bucket_start), SUM(value),
+                    SUM(sample_count), MIN(minimum), MAX(maximum)
+                FROM metric_rollups_hourly
+                WHERE bucket_start >= ?
+                GROUP BY series_id, 2
+                ON CONFLICT(series_id, bucket_start) DO UPDATE SET
+                    value=excluded.value,
+                    sample_count=excluded.sample_count,
+                    minimum=excluded.minimum,
+                    maximum=excluded.maximum
+                """,
+                (daily_cutoff,),
+            )
+            deleted["raw_points"] = connection.execute(
+                "DELETE FROM metric_points WHERE observed_at < ?", (raw_cutoff,)
+            ).rowcount
+            connection.execute("DELETE FROM ingest_batches WHERE received_at < ?", (raw_cutoff,))
+            connection.execute(
+                "DELETE FROM working_tree_snapshots WHERE observed_at < ?", (raw_cutoff,)
+            )
+            deleted["hourly_rollups"] = connection.execute(
+                "DELETE FROM metric_rollups_hourly WHERE bucket_start < ?", (hourly_cutoff,)
+            ).rowcount
+            deleted["daily_rollups"] = connection.execute(
+                "DELETE FROM metric_rollups_daily WHERE bucket_start < ?", (daily_cutoff,)
+            ).rowcount
+            connection.execute("DELETE FROM code_commits WHERE committed_at < ?", (daily_cutoff,))
+            connection.execute(
+                """
+                DELETE FROM metric_series
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM metric_points WHERE metric_points.series_id=metric_series.id
+                ) AND NOT EXISTS (
+                    SELECT 1 FROM metric_rollups_hourly
+                    WHERE metric_rollups_hourly.series_id=metric_series.id
+                ) AND NOT EXISTS (
+                    SELECT 1 FROM metric_rollups_daily
+                    WHERE metric_rollups_daily.series_id=metric_series.id
+                )
+                """
+            )
+            connection.commit()
+            connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            connection.execute("PRAGMA optimize")
+            return deleted
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    def _backup_sync(self, destination: Path) -> None:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        source = self._connect()
+        target = sqlite3.connect(destination)
+        try:
+            source.backup(target)
+        finally:
+            target.close()
+            source.close()
+
+    def _database_size_sync(self) -> int:
+        return sum(
+            candidate.stat().st_size
+            for candidate in (
+                self.path,
+                Path(f"{self.path}-wal"),
+                Path(f"{self.path}-shm"),
+            )
+            if candidate.exists()
+        )
+
+
+def _summarize_ai(rows: Iterable[sqlite3.Row]) -> dict[str, Any]:
+    providers: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        provider = str(row["provider"])
+        attributes = json.loads(row["attributes_json"])
+        if attributes.get("session_source") == "auxiliary":
+            continue
+        current = providers.setdefault(
+            provider,
+            {
+                "sessions": 0.0,
+                "tokens": {},
+                "cost_usd": None,
+                "active_seconds": None,
+                "ai_lines": {},
+                "models": {},
+            },
+        )
+        value = float(row["value"] or 0)
+        name = str(row["metric_name"])
+        model = row["model"]
+        if name in {"claude_code.session.count", "codex.process.start"}:
+            current["sessions"] += value
+        elif name == "claude_code.token.usage":
+            token_type = str(attributes.get("type", "unknown"))
+            current["tokens"][token_type] = current["tokens"].get(token_type, 0.0) + value
+        elif name == "codex.turn.token_usage":
+            token_type = str(attributes.get("token_type", attributes.get("type", "unknown")))
+            current["tokens"][token_type] = current["tokens"].get(token_type, 0.0) + value
+        elif name == "claude_code.cost.usage":
+            current["cost_usd"] = float(current["cost_usd"] or 0) + value
+        elif name == "claude_code.active_time.total":
+            current["active_seconds"] = float(current["active_seconds"] or 0) + value
+        elif name == "claude_code.lines_of_code.count":
+            line_type = str(attributes.get("type", "unknown"))
+            current["ai_lines"][line_type] = current["ai_lines"].get(line_type, 0.0) + value
+        if model:
+            current["models"][str(model)] = current["models"].get(str(model), 0.0) + value
+
+    for provider, values in providers.items():
+        tokens = values["tokens"]
+        if provider == "codex":
+            values["total_tokens"] = int(
+                tokens.get("total", tokens.get("input", 0) + tokens.get("output", 0))
+            )
+            values["cost_usd"] = None
+        else:
+            values["total_tokens"] = int(tokens.get("input", 0) + tokens.get("output", 0))
+        values["sessions"] = int(values["sessions"])
+        values["tokens"] = {key: int(value) for key, value in sorted(tokens.items())}
+        values["ai_lines"] = {key: int(value) for key, value in sorted(values["ai_lines"].items())}
+        values["models"] = sorted(values["models"])
+    reported_costs = [
+        float(item["cost_usd"]) for item in providers.values() if item["cost_usd"] is not None
+    ]
+    reported_active_time = [
+        float(item["active_seconds"])
+        for item in providers.values()
+        if item["active_seconds"] is not None
+    ]
+    reported_ai_lines = [
+        sum(int(value) for value in item["ai_lines"].values())
+        for item in providers.values()
+        if item["ai_lines"]
+    ]
+    totals = {
+        "sessions": sum(item["sessions"] for item in providers.values()),
+        "tokens": sum(int(item.get("total_tokens", 0)) for item in providers.values()),
+        "provider_reported_cost_usd": sum(reported_costs) if reported_costs else None,
+        "active_seconds": sum(reported_active_time) if reported_active_time else None,
+        "ai_lines": sum(reported_ai_lines) if reported_ai_lines else None,
+    }
+    return {"totals": totals, "providers": providers}
+
+
+def _normalize_series(rows: Iterable[sqlite3.Row], metric: str) -> list[dict[str, Any]]:
+    buckets: dict[tuple[str, str], float] = {}
+    codex_totals: set[tuple[str, str]] = set()
+    for row in rows:
+        attributes = json.loads(row["attributes_json"])
+        if attributes.get("session_source") == "auxiliary":
+            continue
+        bucket = str(row["bucket"])
+        provider = str(row["provider"])
+        key = (bucket, provider)
+        value = float(row["value"] or 0)
+        if metric == "tokens":
+            token_type = attributes.get("token_type", attributes.get("type"))
+            if provider == "codex" and token_type == "total":
+                buckets[key] = value
+                codex_totals.add(key)
+            elif (
+                provider == "codex"
+                and key not in codex_totals
+                and token_type in {"input", "output"}
+            ) or (provider != "codex" and token_type in {"input", "output"}):
+                buckets[key] = buckets.get(key, 0) + value
+        else:
+            buckets[key] = buckets.get(key, 0) + value
+    return [
+        {"bucket": bucket, "provider": provider, "value": value}
+        for (bucket, provider), value in sorted(buckets.items())
+    ]
+
+
+def _metric_dimension_filter(filters: QueryFilters) -> tuple[str, list[Any]]:
+    conditions = ["1=1"]
+    parameters: list[Any] = []
+    if filters.box:
+        conditions.append("i.name = ?")
+        parameters.append(filters.box)
+    if filters.instance_id:
+        conditions.append("i.id = ?")
+        parameters.append(filters.instance_id)
+    if filters.provider:
+        conditions.append("s.provider = ?")
+        parameters.append(filters.provider)
+    if filters.model:
+        conditions.append("s.model = ?")
+        parameters.append(filters.model)
+    return " AND ".join(conditions), parameters
+
+
+def _git_filter(filters: QueryFilters) -> tuple[str, list[Any]]:
+    conditions = ["c.committed_at >= ?", "c.committed_at <= ?"]
+    parameters: list[Any] = [filters.since.isoformat(), filters.until.isoformat()]
+    if filters.box:
+        conditions.append("i.name = ?")
+        parameters.append(filters.box)
+    if filters.instance_id:
+        conditions.append("i.id = ?")
+        parameters.append(filters.instance_id)
+    if filters.repo:
+        conditions.append("r.repo_key = ?")
+        parameters.append(filters.repo)
+    return " AND ".join(conditions), parameters
+
+
+def _summary_has_data(summary: dict[str, Any]) -> bool:
+    totals = summary["ai"]["totals"]
+    code = summary["code"]
+    worktree = code["working_tree"]
+    return bool(
+        totals["sessions"]
+        or totals["tokens"]
+        or totals["provider_reported_cost_usd"]
+        or totals["active_seconds"]
+        or totals.get("ai_lines")
+        or code["commits"]
+        or code["additions"]
+        or code["deletions"]
+        or any(worktree.values())
+    )
+
+
+def _attribute_dict(attributes: object) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    if not isinstance(attributes, list):
+        return result
+    for item in attributes:
+        if not isinstance(item, dict):
+            continue
+        value = item.get("value", {})
+        if not isinstance(value, dict):
+            continue
+        for value_key in ("stringValue", "boolValue", "intValue", "doubleValue"):
+            if value_key in value:
+                result[str(item.get("key"))] = value[value_key]
+                break
+    return result
+
+
+def _provider(metric_name: str, service_name: str) -> str:
+    combined = f"{metric_name} {service_name}".lower()
+    if "claude" in combined or "anthropic" in combined:
+        return "claude"
+    if "codex" in combined or "openai" in combined:
+        return "codex"
+    return "unknown"
+
+
+def _temporality(value: object) -> str:
+    if value in {1, "1"}:
+        return "delta"
+    if value in {2, "2"}:
+        return "cumulative"
+    return "unspecified"
+
+
+def _point_value(point: dict[str, Any]) -> float:
+    for key in ("asDouble", "asInt", "sum", "count"):
+        if key in point:
+            return float(point[key])
+    raise ValueError("metric point has no value")
+
+
+def _point_time(point: dict[str, Any], key: str, now: datetime) -> str:
+    parsed = _nanos_datetime(point.get(key))
+    if parsed < _MINIMUM_TIMESTAMP or parsed > now + timedelta(minutes=5):
+        raise ValueError("metric timestamp is outside the accepted range")
+    return parsed.isoformat()
+
+
+def _optional_point_time(point: dict[str, Any], key: str, now: datetime) -> str | None:
+    if key not in point:
+        return None
+    return _point_time(point, key, now)
+
+
+def _nanos_datetime(value: object) -> datetime:
+    if isinstance(value, bool) or not isinstance(value, (str, int)):
+        raise ValueError("invalid metric timestamp")
+    nanoseconds = int(value)
+    return datetime.fromtimestamp(nanoseconds / 1_000_000_000, UTC)
+
+
+def _safe_int(value: object, *, default: int) -> int:
+    return (
+        value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else default
+    )
+
+
+def _now_text() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _canonical(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _parse_datetime(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def _encode_cursor(identifier: int) -> str:
+    return base64.urlsafe_b64encode(str(identifier).encode()).decode().rstrip("=")
+
+
+def _decode_cursor(cursor: str | None) -> int | None:
+    if cursor is None:
+        return None
+    try:
+        padded = cursor + "=" * (-len(cursor) % 4)
+        identifier = int(base64.urlsafe_b64decode(padded).decode())
+    except (ValueError, UnicodeDecodeError) as error:
+        raise ValueError("invalid activity cursor") from error
+    if identifier <= 0:
+        raise ValueError("invalid activity cursor")
+    return identifier
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version INTEGER PRIMARY KEY,
+    applied_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS devbox_instances (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    first_seen_at TEXT NOT NULL,
+    last_seen_at TEXT NOT NULL,
+    deleted_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_instances_name ON devbox_instances(name);
+CREATE TABLE IF NOT EXISTS collectors (
+    id INTEGER PRIMARY KEY,
+    instance_id TEXT NOT NULL REFERENCES devbox_instances(id) ON DELETE CASCADE,
+    kind TEXT NOT NULL,
+    version TEXT NOT NULL,
+    status TEXT NOT NULL,
+    capability_reason TEXT,
+    last_seen_at TEXT NOT NULL,
+    queue_bytes INTEGER NOT NULL DEFAULT 0,
+    dropped_batches INTEGER NOT NULL DEFAULT 0,
+    dropped_points INTEGER NOT NULL DEFAULT 0,
+    provider_versions_json TEXT NOT NULL DEFAULT '{}',
+    last_successful_send_at TEXT,
+    last_error_category TEXT,
+    UNIQUE(instance_id, kind)
+);
+CREATE TABLE IF NOT EXISTS ingest_batches (
+    batch_id TEXT PRIMARY KEY,
+    instance_id TEXT NOT NULL REFERENCES devbox_instances(id) ON DELETE CASCADE,
+    received_at TEXT NOT NULL,
+    sent_at TEXT NOT NULL,
+    collector TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    point_count INTEGER NOT NULL,
+    fingerprint TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_batches_instance_time
+    ON ingest_batches(instance_id, received_at);
+CREATE TABLE IF NOT EXISTS metric_series (
+    id INTEGER PRIMARY KEY,
+    instance_id TEXT NOT NULL REFERENCES devbox_instances(id) ON DELETE CASCADE,
+    metric_name TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    model TEXT,
+    unit TEXT NOT NULL,
+    form TEXT NOT NULL,
+    temporality TEXT NOT NULL,
+    monotonic INTEGER NOT NULL,
+    attributes_json TEXT NOT NULL,
+    series_hash TEXT NOT NULL UNIQUE
+);
+CREATE INDEX IF NOT EXISTS idx_series_dimensions
+    ON metric_series(metric_name, provider, model, instance_id);
+CREATE TABLE IF NOT EXISTS metric_points (
+    id INTEGER PRIMARY KEY,
+    series_id INTEGER NOT NULL REFERENCES metric_series(id) ON DELETE CASCADE,
+    batch_id TEXT NOT NULL,
+    observed_at TEXT NOT NULL,
+    start_at TEXT,
+    value REAL NOT NULL,
+    raw_value REAL NOT NULL,
+    payload_json TEXT NOT NULL,
+    fingerprint TEXT NOT NULL UNIQUE
+);
+CREATE INDEX IF NOT EXISTS idx_points_series_time ON metric_points(series_id, observed_at);
+CREATE INDEX IF NOT EXISTS idx_points_time ON metric_points(observed_at);
+CREATE TABLE IF NOT EXISTS metric_rollups_hourly (
+    series_id INTEGER NOT NULL REFERENCES metric_series(id) ON DELETE CASCADE,
+    bucket_start TEXT NOT NULL,
+    value REAL NOT NULL,
+    sample_count INTEGER NOT NULL,
+    minimum REAL NOT NULL,
+    maximum REAL NOT NULL,
+    PRIMARY KEY(series_id, bucket_start)
+);
+CREATE INDEX IF NOT EXISTS idx_hourly_bucket ON metric_rollups_hourly(bucket_start);
+CREATE TABLE IF NOT EXISTS metric_rollups_daily (
+    series_id INTEGER NOT NULL REFERENCES metric_series(id) ON DELETE CASCADE,
+    bucket_start TEXT NOT NULL,
+    value REAL NOT NULL,
+    sample_count INTEGER NOT NULL,
+    minimum REAL NOT NULL,
+    maximum REAL NOT NULL,
+    PRIMARY KEY(series_id, bucket_start)
+);
+CREATE INDEX IF NOT EXISTS idx_daily_bucket ON metric_rollups_daily(bucket_start);
+CREATE TABLE IF NOT EXISTS repositories (
+    id INTEGER PRIMARY KEY,
+    instance_id TEXT NOT NULL REFERENCES devbox_instances(id) ON DELETE CASCADE,
+    repo_key TEXT NOT NULL,
+    first_seen_at TEXT NOT NULL,
+    last_seen_at TEXT NOT NULL,
+    UNIQUE(instance_id, repo_key)
+);
+CREATE INDEX IF NOT EXISTS idx_repositories_key ON repositories(repo_key, instance_id);
+CREATE TABLE IF NOT EXISTS code_commits (
+    id INTEGER PRIMARY KEY,
+    instance_id TEXT NOT NULL REFERENCES devbox_instances(id) ON DELETE CASCADE,
+    repository_id INTEGER NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+    batch_id TEXT NOT NULL,
+    sha TEXT NOT NULL,
+    committed_at TEXT NOT NULL,
+    additions INTEGER NOT NULL,
+    deletions INTEGER NOT NULL,
+    files_changed INTEGER NOT NULL,
+    binary_files INTEGER NOT NULL,
+    is_merge INTEGER NOT NULL,
+    UNIQUE(repository_id, sha)
+);
+CREATE INDEX IF NOT EXISTS idx_commits_time_repo ON code_commits(committed_at, repository_id);
+CREATE TABLE IF NOT EXISTS working_tree_snapshots (
+    id INTEGER PRIMARY KEY,
+    instance_id TEXT NOT NULL REFERENCES devbox_instances(id) ON DELETE CASCADE,
+    repository_id INTEGER NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+    batch_id TEXT NOT NULL,
+    observed_at TEXT NOT NULL,
+    staged_additions INTEGER NOT NULL,
+    staged_deletions INTEGER NOT NULL,
+    staged_files INTEGER NOT NULL,
+    unstaged_additions INTEGER NOT NULL,
+    unstaged_deletions INTEGER NOT NULL,
+    unstaged_files INTEGER NOT NULL,
+    binary_files INTEGER NOT NULL,
+    fingerprint TEXT NOT NULL UNIQUE
+);
+CREATE INDEX IF NOT EXISTS idx_worktree_repo_time
+    ON working_tree_snapshots(repository_id, observed_at);
+INSERT OR IGNORE INTO schema_migrations(version, applied_at)
+    VALUES (1, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));
+"""

--- a/controller/src/devboxes_controller/manager.py
+++ b/controller/src/devboxes_controller/manager.py
@@ -1,8 +1,11 @@
 """Manage the Kubernetes resources that implement devbox lifecycles."""
 
 import asyncio
+import base64
 import builtins
+import hmac
 import logging
+import uuid
 from collections.abc import Iterable
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -11,18 +14,23 @@ from kubernetes import client, config
 from kubernetes.client.exceptions import ApiException
 from kubernetes.utils.quantity import parse_quantity
 
+from .auth import Authenticator
 from .config import Settings
 from .models import (
     CreateDevboxRequest,
     DeleteResult,
     Devbox,
     DevboxState,
+    InsightsState,
     Preset,
 )
 from .resources import (
     ANNOTATION_AUTO_STOPPED_AT,
     ANNOTATION_CREATED_AT,
     ANNOTATION_EXPIRES_AT,
+    ANNOTATION_INSIGHTS_STATE,
+    ANNOTATION_INSIGHTS_TEMPLATE_HASH,
+    ANNOTATION_INSTANCE_ID,
     ANNOTATION_PRESET,
     ANNOTATION_REPOSITORY,
     ANNOTATION_STORAGE,
@@ -62,6 +70,7 @@ class DevboxManager:
             self._load_config(settings)
         self.apps = apps_api or client.AppsV1Api()
         self.core = core_api or client.CoreV1Api()
+        self.authenticator = Authenticator(settings)
 
     @staticmethod
     def _load_config(settings: Settings) -> None:
@@ -96,9 +105,19 @@ class DevboxManager:
         pvc_name = f"{name}-home"
         desired_storage = PRESETS[request.preset]["storage"]
         existing_pvc = await self._read_pvc(pvc_name)
+        instance_id = (
+            await self._instance_id(pvc_name, existing_pvc)
+            if self.settings.insights_enabled
+            else None
+        )
         storage_size = desired_storage
         if existing_pvc is None:
-            pvc = build_pvc(request, self.settings.namespace, self.settings.storage_class)
+            pvc = build_pvc(
+                request,
+                self.settings.namespace,
+                self.settings.storage_class,
+                instance_id,
+            )
             await asyncio.to_thread(
                 self.core.create_namespaced_persistent_volume_claim,
                 self.settings.namespace,
@@ -118,6 +137,18 @@ class DevboxManager:
             else:
                 storage_size = current_storage
 
+        insights_credential = (
+            self.authenticator.issue_insights_token(instance_id, request.name)
+            if instance_id is not None
+            else None
+        )
+        insights_secret_name = None
+        if insights_credential is not None and instance_id is not None:
+            insights_secret_name = await self._ensure_insights_secret(
+                request.name,
+                instance_id,
+                insights_credential,
+            )
         deployment = build_deployment(
             request,
             self.settings.namespace,
@@ -126,6 +157,15 @@ class DevboxManager:
             self.settings.workspace_service_account_name,
             self.settings.workspace_priority_class,
             self.settings.image_pull_secret,
+            instance_id=instance_id,
+            insights_enabled=self.settings.insights_enabled,
+            insights_endpoint=self.settings.insights_controller_url,
+            insights_credential=insights_credential,
+            insights_secret_name=insights_secret_name,
+            insights_scan_interval_seconds=self.settings.insights_agent_scan_interval_seconds,
+            insights_repository_depth=self.settings.insights_agent_repository_depth,
+            insights_max_queue_bytes=self.settings.insights_agent_max_queue_bytes,
+            insights_max_queue_age_seconds=self.settings.insights_agent_max_queue_age_seconds,
         )
         deployment["metadata"]["annotations"][ANNOTATION_STORAGE] = storage_size
         service = build_service(
@@ -138,12 +178,12 @@ class DevboxManager:
             self.settings.workspace_external_traffic_policy,
             self.settings.workspace_load_balancer_source_ranges,
         )
-        await asyncio.to_thread(
-            self.apps.create_namespaced_deployment,
-            self.settings.namespace,
-            deployment,
-        )
         try:
+            await asyncio.to_thread(
+                self.apps.create_namespaced_deployment,
+                self.settings.namespace,
+                deployment,
+            )
             await asyncio.to_thread(
                 self.core.create_namespaced_service,
                 self.settings.namespace,
@@ -151,6 +191,8 @@ class DevboxManager:
             )
         except Exception:
             await self._delete_deployment(name)
+            if insights_secret_name:
+                await self._delete_secret(insights_secret_name)
             raise
         return await self.get(request.name)
 
@@ -229,6 +271,7 @@ class DevboxManager:
                     resource,
                     self.settings.namespace,
                 )
+                deployment = await self._prepare_insights_template(deployment)
                 annotations = deployment.metadata.annotations or {}
                 ttl_hours = _ttl_hours(
                     annotations.get(ANNOTATION_TTL_HOURS),
@@ -264,6 +307,49 @@ class DevboxManager:
             raise
         return await self.get(name)
 
+    async def reconcile_insights(self) -> builtins.list[str]:
+        """Reconcile identity and safe collector state without restarting active workspaces."""
+        if not self.settings.insights_enabled:
+            return []
+        selector = f"{LABEL_MANAGED_BY}={MANAGED_BY}"
+        deployments = await asyncio.to_thread(
+            self.apps.list_namespaced_deployment,
+            self.settings.namespace,
+            label_selector=selector,
+        )
+        changed: builtins.list[str] = []
+        for deployment in deployments.items:
+            name = deployment.metadata.labels.get(LABEL_NAME)
+            if not name:
+                continue
+            if (deployment.spec.replicas or 0) == 0:
+                prepared = await self._prepare_insights_template(deployment)
+                if prepared is not deployment:
+                    changed.append(name)
+            else:
+                annotations = deployment.metadata.annotations or {}
+                desired, instance_id = await self._desired_insights_deployment(deployment)
+                if not _insights_template_matches(deployment, desired) and (
+                    annotations.get(ANNOTATION_INSIGHTS_STATE)
+                    != InsightsState.RESTART_REQUIRED.value
+                    or annotations.get(ANNOTATION_INSTANCE_ID) != instance_id
+                ):
+                    await asyncio.to_thread(
+                        self.apps.patch_namespaced_deployment,
+                        deployment.metadata.name,
+                        self.settings.namespace,
+                        {
+                            "metadata": {
+                                "annotations": {
+                                    ANNOTATION_INSIGHTS_STATE: InsightsState.RESTART_REQUIRED.value,
+                                    ANNOTATION_INSTANCE_ID: instance_id,
+                                }
+                            }
+                        },
+                    )
+                    changed.append(name)
+        return changed
+
     async def delete(self, name: str, purge: bool) -> DeleteResult:
         """Delete compute and SSH resources, optionally deleting storage."""
         resource = resource_name(name)
@@ -272,6 +358,7 @@ class DevboxManager:
         await asyncio.gather(
             self._delete_deployment(resource),
             self._delete_service(f"{resource}-ssh"),
+            self._delete_secret(f"{resource}-insights"),
         )
         if purge:
             await self._delete_pvc(f"{resource}-home")
@@ -329,6 +416,167 @@ class DevboxManager:
                 return None
             raise
 
+    async def _instance_id(self, pvc_name: str, pvc: Any | None) -> str:
+        if pvc is not None:
+            annotations = getattr(getattr(pvc, "metadata", None), "annotations", None) or {}
+            candidate = annotations.get(ANNOTATION_INSTANCE_ID)
+            if candidate and _valid_instance_id(candidate):
+                return str(candidate)
+        instance_id = str(uuid.uuid4())
+        if pvc is not None:
+            await asyncio.to_thread(
+                self.core.patch_namespaced_persistent_volume_claim,
+                pvc_name,
+                self.settings.namespace,
+                {"metadata": {"annotations": {ANNOTATION_INSTANCE_ID: instance_id}}},
+            )
+        return instance_id
+
+    async def _ensure_insights_secret(
+        self,
+        box_name: str,
+        instance_id: str,
+        credential: str,
+    ) -> str:
+        secret_name = f"{resource_name(box_name)}-insights"
+        body = {
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": {
+                "name": secret_name,
+                "namespace": self.settings.namespace,
+                "labels": {
+                    LABEL_MANAGED_BY: MANAGED_BY,
+                    LABEL_NAME: box_name,
+                },
+                "annotations": {ANNOTATION_INSTANCE_ID: instance_id},
+            },
+            "type": "Opaque",
+            "stringData": {"credential": credential},
+        }
+        try:
+            existing = await asyncio.to_thread(
+                self.core.read_namespaced_secret,
+                secret_name,
+                self.settings.namespace,
+            )
+        except ApiException as error:
+            if error.status != 404:
+                raise
+            await asyncio.to_thread(
+                self.core.create_namespaced_secret,
+                self.settings.namespace,
+                body,
+            )
+        else:
+            annotations = getattr(getattr(existing, "metadata", None), "annotations", None) or {}
+            data = getattr(existing, "data", None)
+            encoded = data.get("credential") if isinstance(data, dict) else None
+            try:
+                current = base64.b64decode(encoded, validate=True).decode() if encoded else ""
+            except (TypeError, ValueError, UnicodeDecodeError):
+                current = ""
+            if annotations.get(ANNOTATION_INSTANCE_ID) != instance_id or not hmac.compare_digest(
+                current, credential
+            ):
+                await asyncio.to_thread(
+                    self.core.patch_namespaced_secret,
+                    secret_name,
+                    self.settings.namespace,
+                    {
+                        "metadata": {"annotations": {ANNOTATION_INSTANCE_ID: instance_id}},
+                        "stringData": {"credential": credential},
+                    },
+                )
+        return secret_name
+
+    async def _prepare_insights_template(self, deployment: Any) -> Any:
+        if not self.settings.insights_enabled:
+            return deployment
+        desired, instance_id = await self._desired_insights_deployment(deployment)
+        annotations = deployment.metadata.annotations or {}
+        if _insights_template_matches(deployment, desired):
+            if annotations.get(ANNOTATION_INSIGHTS_STATE) == InsightsState.COLLECTING.value:
+                return deployment
+            await asyncio.to_thread(
+                self.apps.patch_namespaced_deployment,
+                deployment.metadata.name,
+                self.settings.namespace,
+                {
+                    "metadata": {
+                        "annotations": {
+                            ANNOTATION_INSTANCE_ID: instance_id,
+                            ANNOTATION_INSIGHTS_STATE: InsightsState.COLLECTING.value,
+                        }
+                    }
+                },
+            )
+            return await asyncio.to_thread(
+                self.apps.read_namespaced_deployment,
+                deployment.metadata.name,
+                self.settings.namespace,
+            )
+        await asyncio.to_thread(
+            self.apps.patch_namespaced_deployment,
+            deployment.metadata.name,
+            self.settings.namespace,
+            {
+                "metadata": {
+                    "annotations": {
+                        ANNOTATION_INSTANCE_ID: instance_id,
+                        ANNOTATION_INSIGHTS_STATE: InsightsState.COLLECTING.value,
+                        ANNOTATION_INSIGHTS_TEMPLATE_HASH: desired["metadata"]["annotations"][
+                            ANNOTATION_INSIGHTS_TEMPLATE_HASH
+                        ],
+                    }
+                },
+                "spec": {"template": desired["spec"]["template"]},
+            },
+        )
+        return await asyncio.to_thread(
+            self.apps.read_namespaced_deployment,
+            deployment.metadata.name,
+            self.settings.namespace,
+        )
+
+    async def _desired_insights_deployment(self, deployment: Any) -> tuple[dict[str, Any], str]:
+        annotations = deployment.metadata.annotations or {}
+        name = deployment.metadata.labels[LABEL_NAME]
+        pvc_name = f"{resource_name(name)}-home"
+        pvc = await self._read_pvc(pvc_name)
+        instance_id = await self._instance_id(pvc_name, pvc)
+        request = CreateDevboxRequest(
+            name=name,
+            preset=Preset(annotations.get(ANNOTATION_PRESET, Preset.SMALL.value)),
+            ttl_hours=_ttl_hours(
+                annotations.get(ANNOTATION_TTL_HOURS),
+                self.settings.default_ttl_hours,
+                self.settings.max_ttl_hours,
+            ),
+            repository=annotations.get(ANNOTATION_REPOSITORY),
+        )
+        credential = self.authenticator.issue_insights_token(instance_id, name)
+        secret_name = await self._ensure_insights_secret(name, instance_id, credential)
+        desired = build_deployment(
+            request,
+            self.settings.namespace,
+            self.settings.workspace_image,
+            self.settings.workspace_secret_name,
+            self.settings.workspace_service_account_name,
+            self.settings.workspace_priority_class,
+            self.settings.image_pull_secret,
+            instance_id=instance_id,
+            insights_enabled=True,
+            insights_endpoint=self.settings.insights_controller_url,
+            insights_credential=credential,
+            insights_secret_name=secret_name,
+            insights_scan_interval_seconds=self.settings.insights_agent_scan_interval_seconds,
+            insights_repository_depth=self.settings.insights_agent_repository_depth,
+            insights_max_queue_bytes=self.settings.insights_agent_max_queue_bytes,
+            insights_max_queue_age_seconds=self.settings.insights_agent_max_queue_age_seconds,
+        )
+        return desired, instance_id
+
     async def _delete_deployment(self, name: str) -> None:
         await self._ignore_not_found(
             self.apps.delete_namespaced_deployment,
@@ -348,6 +596,14 @@ class DevboxManager:
     async def _delete_pvc(self, name: str) -> None:
         await self._ignore_not_found(
             self.core.delete_namespaced_persistent_volume_claim,
+            name,
+            self.settings.namespace,
+            body=client.V1DeleteOptions(),
+        )
+
+    async def _delete_secret(self, name: str) -> None:
+        await self._ignore_not_found(
+            self.core.delete_namespaced_secret,
             name,
             self.settings.namespace,
             body=client.V1DeleteOptions(),
@@ -389,6 +645,8 @@ class DevboxManager:
             restarts=restarts,
             storage_size=annotations.get(ANNOTATION_STORAGE, "20Gi"),
             message=message,
+            instance_id=annotations.get(ANNOTATION_INSTANCE_ID),
+            insights_state=_insights_state(self.settings.insights_enabled, deployment, desired),
         )
 
 
@@ -476,3 +734,53 @@ def _state(
     if pod_ready:
         return DevboxState.STARTING, "Waiting for an SSH service address"
     return DevboxState.STARTING, "Preparing workspace and SSH"
+
+
+def _valid_instance_id(value: str) -> bool:
+    try:
+        parsed = uuid.UUID(value)
+    except ValueError:
+        return False
+    return parsed.version == 4 and str(parsed) == value
+
+
+def _has_insights_sidecar(deployment: Any) -> bool:
+    containers = getattr(
+        getattr(getattr(deployment, "spec", None), "template", None),
+        "spec",
+        None,
+    )
+    return any(
+        getattr(container, "name", None) == "insights-agent"
+        for container in (getattr(containers, "containers", None) or [])
+    )
+
+
+def _insights_template_matches(deployment: Any, desired: dict[str, Any]) -> bool:
+    if not _has_insights_sidecar(deployment):
+        return False
+    desired_annotations = desired["metadata"]["annotations"]
+    desired_hash = desired_annotations.get(ANNOTATION_INSIGHTS_TEMPLATE_HASH)
+    deployment_annotations = deployment.metadata.annotations or {}
+    template = getattr(getattr(deployment, "spec", None), "template", None)
+    template_annotations = getattr(getattr(template, "metadata", None), "annotations", None) or {}
+    return bool(
+        desired_hash
+        and deployment_annotations.get(ANNOTATION_INSIGHTS_TEMPLATE_HASH) == desired_hash
+        and template_annotations.get(ANNOTATION_INSIGHTS_TEMPLATE_HASH) == desired_hash
+        and deployment_annotations.get(ANNOTATION_INSTANCE_ID)
+        == desired_annotations.get(ANNOTATION_INSTANCE_ID)
+    )
+
+
+def _insights_state(enabled: bool, deployment: Any, desired: int) -> InsightsState:
+    if not enabled:
+        return InsightsState.DISABLED
+    annotations = deployment.metadata.annotations or {}
+    if annotations.get(ANNOTATION_INSIGHTS_STATE) == InsightsState.RESTART_REQUIRED.value:
+        return InsightsState.RESTART_REQUIRED
+    if _has_insights_sidecar(deployment):
+        return InsightsState.COLLECTING
+    if desired > 0:
+        return InsightsState.RESTART_REQUIRED
+    return InsightsState.RESTART_REQUIRED

--- a/controller/src/devboxes_controller/models.py
+++ b/controller/src/devboxes_controller/models.py
@@ -29,6 +29,14 @@ class DevboxState(StrEnum):
     DEGRADED = "degraded"
 
 
+class InsightsState(StrEnum):
+    """Describe whether a workspace collector is active or awaits a safe restart."""
+
+    DISABLED = "disabled"
+    COLLECTING = "collecting"
+    RESTART_REQUIRED = "restart_required"
+
+
 class CreateDevboxRequest(BaseModel):
     """Validate a request to create a devbox."""
 
@@ -79,6 +87,8 @@ class Devbox(BaseModel):
     restarts: int = 0
     storage_size: str
     message: str | None = None
+    instance_id: str | None = None
+    insights_state: InsightsState = InsightsState.DISABLED
 
 
 class DevboxList(BaseModel):

--- a/controller/src/devboxes_controller/resources.py
+++ b/controller/src/devboxes_controller/resources.py
@@ -1,5 +1,7 @@
 """Build Kubernetes manifests for managed devbox resources."""
 
+import hashlib
+import json
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -15,6 +17,9 @@ ANNOTATION_REPOSITORY = "devboxes.bonalab.org/repository"
 ANNOTATION_PRESET = "devboxes.bonalab.org/preset"
 ANNOTATION_STORAGE = "devboxes.bonalab.org/storage-size"
 ANNOTATION_AUTO_STOPPED_AT = "devboxes.bonalab.org/auto-stopped-at"
+ANNOTATION_INSTANCE_ID = "insights.devboxes.bonalab.org/instance-id"
+ANNOTATION_INSIGHTS_STATE = "insights.devboxes.bonalab.org/state"
+ANNOTATION_INSIGHTS_TEMPLATE_HASH = "insights.devboxes.bonalab.org/template-hash"
 
 
 PRESETS: dict[Preset, dict[str, str]] = {
@@ -55,7 +60,11 @@ def labels(name: str) -> dict[str, str]:
     }
 
 
-def annotations(request: CreateDevboxRequest, now: datetime | None = None) -> dict[str, str]:
+def annotations(
+    request: CreateDevboxRequest,
+    now: datetime | None = None,
+    instance_id: str | None = None,
+) -> dict[str, str]:
     """Return lifecycle and user-input annotations for a new devbox."""
     now = now or datetime.now(UTC)
     result = {
@@ -67,6 +76,8 @@ def annotations(request: CreateDevboxRequest, now: datetime | None = None) -> di
     }
     if request.repository:
         result[ANNOTATION_REPOSITORY] = request.repository
+    if instance_id:
+        result[ANNOTATION_INSTANCE_ID] = instance_id
     return result
 
 
@@ -74,6 +85,7 @@ def build_pvc(
     request: CreateDevboxRequest,
     namespace: str,
     storage_class: str | None,
+    instance_id: str | None = None,
 ) -> dict[str, Any]:
     """Build the persistent home volume claim for a devbox."""
     manifest: dict[str, Any] = {
@@ -83,6 +95,9 @@ def build_pvc(
             "name": f"{resource_name(request.name)}-home",
             "namespace": namespace,
             "labels": labels(request.name),
+            "annotations": (
+                {ANNOTATION_INSTANCE_ID: instance_id} if instance_id is not None else {}
+            ),
         },
         "spec": {
             "accessModes": ["ReadWriteOnce"],
@@ -103,6 +118,15 @@ def build_deployment(
     workspace_priority_class: str | None = None,
     image_pull_secret: str | None = None,
     now: datetime | None = None,
+    instance_id: str | None = None,
+    insights_enabled: bool = False,
+    insights_endpoint: str | None = None,
+    insights_credential: str | None = None,
+    insights_secret_name: str | None = None,
+    insights_scan_interval_seconds: int = 60,
+    insights_repository_depth: int = 4,
+    insights_max_queue_bytes: int = 134_217_728,
+    insights_max_queue_age_seconds: int = 604_800,
 ) -> dict[str, Any]:
     """Build the disposable workspace Deployment for a devbox."""
     name = resource_name(request.name)
@@ -113,6 +137,34 @@ def build_deployment(
     ]
     if request.repository:
         env.append({"name": "DEVBOX_REPOSITORY", "value": request.repository})
+    if insights_enabled:
+        env.extend(
+            [
+                {"name": "DEVBOXES_INSIGHTS_ENABLED", "value": "true"},
+                {"name": "CLAUDE_CODE_ENABLE_TELEMETRY", "value": "1"},
+                {"name": "OTEL_METRICS_EXPORTER", "value": "otlp"},
+                {"name": "OTEL_LOGS_EXPORTER", "value": "none"},
+                {"name": "OTEL_TRACES_EXPORTER", "value": "none"},
+                {"name": "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL", "value": "http/json"},
+                {
+                    "name": "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+                    "value": "http://127.0.0.1:4318/v1/metrics",
+                },
+                {
+                    "name": "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE",
+                    "value": "delta",
+                },
+                {"name": "OTEL_METRICS_INCLUDE_SESSION_ID", "value": "false"},
+                {"name": "OTEL_METRICS_INCLUDE_ACCOUNT_UUID", "value": "false"},
+                {"name": "OTEL_METRICS_INCLUDE_VERSION", "value": "true"},
+                {"name": "OTEL_METRICS_INCLUDE_RESOURCE_ATTRIBUTES", "value": "false"},
+                {"name": "OTEL_LOG_USER_PROMPTS", "value": "0"},
+                {"name": "OTEL_LOG_ASSISTANT_RESPONSES", "value": "0"},
+                {"name": "OTEL_LOG_TOOL_DETAILS", "value": "0"},
+                {"name": "OTEL_LOG_TOOL_CONTENT", "value": "0"},
+                {"name": "OTEL_LOG_RAW_API_BODIES", "value": "0"},
+            ]
+        )
 
     pod_spec: dict[str, Any] = {
         "serviceAccountName": workspace_service_account_name,
@@ -204,14 +256,77 @@ def build_deployment(
     if image_pull_secret:
         pod_spec["imagePullSecrets"] = [{"name": image_pull_secret}]
 
-    return {
+    if insights_enabled:
+        if not all((instance_id, insights_endpoint, insights_credential)):
+            raise ValueError(
+                "enabled Insights requires instance identity, endpoint, and credential"
+            )
+        credential_environment: dict[str, Any] = {"name": "DEVBOXES_INSIGHTS_CREDENTIAL"}
+        if insights_secret_name:
+            credential_environment["valueFrom"] = {
+                "secretKeyRef": {
+                    "name": insights_secret_name,
+                    "key": "credential",
+                }
+            }
+        else:
+            credential_environment["value"] = insights_credential
+        pod_spec["containers"].append(
+            {
+                "name": "insights-agent",
+                "image": workspace_image,
+                "imagePullPolicy": "IfNotPresent",
+                "command": ["python3", "/usr/local/bin/devbox-insights-agent"],
+                "env": [
+                    {"name": "HOME", "value": "/home/dev"},
+                    {"name": "PYTHONDONTWRITEBYTECODE", "value": "1"},
+                    {"name": "DEVBOXES_INSIGHTS_ENDPOINT", "value": insights_endpoint},
+                    credential_environment,
+                    {
+                        "name": "DEVBOXES_INSIGHTS_SCAN_INTERVAL_SECONDS",
+                        "value": str(insights_scan_interval_seconds),
+                    },
+                    {
+                        "name": "DEVBOXES_INSIGHTS_REPOSITORY_DEPTH",
+                        "value": str(insights_repository_depth),
+                    },
+                    {
+                        "name": "DEVBOXES_INSIGHTS_MAX_QUEUE_BYTES",
+                        "value": str(insights_max_queue_bytes),
+                    },
+                    {
+                        "name": "DEVBOXES_INSIGHTS_MAX_QUEUE_AGE_SECONDS",
+                        "value": str(insights_max_queue_age_seconds),
+                    },
+                ],
+                "resources": {
+                    "requests": {"cpu": "25m", "memory": "32Mi"},
+                    "limits": {"cpu": "200m", "memory": "128Mi"},
+                },
+                "securityContext": {
+                    "runAsNonRoot": True,
+                    "runAsUser": 1000,
+                    "runAsGroup": 1000,
+                    "allowPrivilegeEscalation": False,
+                    "readOnlyRootFilesystem": True,
+                    "capabilities": {"drop": ["ALL"]},
+                },
+                "volumeMounts": [{"name": "home", "mountPath": "/home/dev"}],
+            }
+        )
+
+    deployment_annotations = annotations(request, now, instance_id)
+    deployment_annotations[ANNOTATION_INSIGHTS_STATE] = (
+        "collecting" if insights_enabled else "disabled"
+    )
+    manifest: dict[str, Any] = {
         "apiVersion": "apps/v1",
         "kind": "Deployment",
         "metadata": {
             "name": name,
             "namespace": namespace,
             "labels": box_labels,
-            "annotations": annotations(request, now),
+            "annotations": deployment_annotations,
         },
         "spec": {
             "replicas": 1,
@@ -222,11 +337,34 @@ def build_deployment(
             "strategy": {"type": "Recreate"},
             "selector": {"matchLabels": {LABEL_NAME: request.name}},
             "template": {
-                "metadata": {"labels": box_labels},
+                "metadata": {
+                    "labels": box_labels,
+                    "annotations": (
+                        {ANNOTATION_INSTANCE_ID: instance_id} if instance_id is not None else {}
+                    ),
+                },
                 "spec": pod_spec,
             },
         },
     }
+    if insights_enabled:
+        template_hash = hashlib.sha256(
+            json.dumps(
+                {
+                    "pod_spec": manifest["spec"]["template"]["spec"],
+                    "credential_fingerprint": hashlib.sha256(
+                        str(insights_credential).encode()
+                    ).hexdigest(),
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode()
+        ).hexdigest()
+        manifest["metadata"]["annotations"][ANNOTATION_INSIGHTS_TEMPLATE_HASH] = template_hash
+        manifest["spec"]["template"]["metadata"]["annotations"][
+            ANNOTATION_INSIGHTS_TEMPLATE_HASH
+        ] = template_hash
+    return manifest
 
 
 def build_service(

--- a/controller/src/devboxes_controller/static/insights.js
+++ b/controller/src/devboxes_controller/static/insights.js
@@ -1,0 +1,389 @@
+const enabled = document.body.dataset.insightsEnabled === "true";
+const logoutButton = document.querySelector("#logout-button");
+const refreshButton = document.querySelector("#insights-refresh");
+
+function cookie(name) {
+  const prefix = `${encodeURIComponent(name)}=`;
+  return document.cookie
+    .split("; ")
+    .find((item) => item.startsWith(prefix))
+    ?.slice(prefix.length);
+}
+
+async function api(path, options = {}) {
+  const method = options.method || "GET";
+  const headers = new Headers(options.headers || {});
+  headers.set("Accept", "application/json");
+  if (!["GET", "HEAD", "OPTIONS"].includes(method)) {
+    headers.set(
+      "X-Devboxes-CSRF",
+      decodeURIComponent(cookie("devboxes_csrf") || ""),
+    );
+  }
+  const response = await fetch(path, { ...options, method, headers });
+  if (response.status === 401) {
+    window.location.assign("/login");
+    throw new Error("Your session expired.");
+  }
+  if (!response.ok) {
+    let message = `Request failed (${response.status})`;
+    try {
+      const payload = await response.json();
+      message = payload.detail || message;
+    } catch {
+      // Preserve the status-based message for non-JSON upstream failures.
+    }
+    throw new Error(message);
+  }
+  if (response.status === 204) {
+    return null;
+  }
+  return response.json();
+}
+
+async function signOut() {
+  try {
+    await api("/auth/logout", { method: "POST" });
+  } finally {
+    window.location.assign("/login");
+  }
+}
+
+logoutButton?.addEventListener("click", signOut);
+
+if (!enabled) {
+  refreshButton.disabled = true;
+} else {
+  const elements = {
+    form: document.querySelector("#insights-filters"),
+    range: document.querySelector("#insights-range"),
+    sinceField: document.querySelector("#custom-since-field"),
+    untilField: document.querySelector("#custom-until-field"),
+    since: document.querySelector("#insights-since"),
+    until: document.querySelector("#insights-until"),
+    loading: document.querySelector("#insights-loading"),
+    error: document.querySelector("#insights-error"),
+    empty: document.querySelector("#insights-empty"),
+    content: document.querySelector("#insights-content"),
+    coverage: document.querySelector("#coverage-banner"),
+    coverageCopy: document.querySelector("#coverage-copy"),
+    sessions: document.querySelector("#metric-sessions"),
+    tokens: document.querySelector("#metric-tokens"),
+    cost: document.querySelector("#metric-cost"),
+    active: document.querySelector("#metric-active"),
+    aiLines: document.querySelector("#metric-ai-lines"),
+    commits: document.querySelector("#metric-commits"),
+    additions: document.querySelector("#metric-additions"),
+    deletions: document.querySelector("#metric-deletions"),
+    worktree: document.querySelector("#metric-worktree"),
+    worktreeDetail: document.querySelector("#metric-worktree-detail"),
+    providerTable: document.querySelector("#provider-table"),
+    tokenChart: document.querySelector("#token-chart"),
+    tokenTable: document.querySelector("#token-table"),
+    activity: document.querySelector("#activity-list"),
+    collectors: document.querySelector("#collector-list"),
+  };
+
+  function node(tag, className, text) {
+    const element = document.createElement(tag);
+    if (className) {
+      element.className = className;
+    }
+    if (text !== undefined) {
+      element.textContent = text;
+    }
+    return element;
+  }
+
+  function formatInteger(value) {
+    return new Intl.NumberFormat(undefined, {
+      maximumFractionDigits: 0,
+    }).format(Number(value || 0));
+  }
+
+  function formatMoney(value) {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 4,
+    }).format(Number(value || 0));
+  }
+
+  function formatDuration(seconds) {
+    const minutes = Math.round(Number(seconds || 0) / 60);
+    if (minutes < 60) {
+      return `${minutes}m`;
+    }
+    const hours = Math.floor(minutes / 60);
+    const remainder = minutes % 60;
+    return remainder ? `${hours}h ${remainder}m` : `${hours}h`;
+  }
+
+  function isReported(value) {
+    return value !== null && value !== undefined;
+  }
+
+  function query() {
+    const form = new FormData(elements.form);
+    const parameters = new URLSearchParams();
+    const range = String(form.get("range"));
+    if (range === "custom") {
+      const since = elements.since.valueAsDate;
+      const until = elements.until.valueAsDate;
+      if (!since || !until) {
+        throw new Error("Choose both ends of the custom range.");
+      }
+      parameters.set("since", since.toISOString());
+      parameters.set("until", until.toISOString());
+    } else {
+      parameters.set("since", range);
+    }
+    for (const key of ["box", "provider", "model", "repo"]) {
+      const value = String(form.get(key) || "").trim();
+      if (value) {
+        parameters.set(key, value);
+      }
+    }
+    return parameters;
+  }
+
+  function renderCoverage(coverage) {
+    elements.coverage.dataset.status = coverage.status;
+    const collectorCount = coverage.collectors.length;
+    if (coverage.status === "empty") {
+      elements.coverageCopy.textContent =
+        "Waiting for the first enabled workspace collector.";
+      return;
+    }
+    const freshness = coverage.freshness_seconds;
+    const age =
+      freshness < 60 ? "under a minute" : `${Math.floor(freshness / 60)}m`;
+    const qualification =
+      coverage.status === "fresh"
+        ? "complete"
+        : coverage.status === "partial"
+          ? "partial; inspect collector states below"
+          : "stale";
+    elements.coverageCopy.textContent = `${collectorCount} collector${collectorCount === 1 ? "" : "s"} · newest ${age} ago · coverage ${qualification}`;
+  }
+
+  function renderProviders(summary, capabilities) {
+    const rows = [];
+    for (const provider of ["codex", "claude"]) {
+      const values = summary.providers[provider] || {
+        sessions: 0,
+        total_tokens: 0,
+        models: [],
+      };
+      const row = document.createElement("tr");
+      const name = document.createElement("th");
+      name.scope = "row";
+      name.textContent = provider === "codex" ? "Codex" : "Claude";
+      const cost =
+        capabilities[provider].cost.supported && isReported(values.cost_usd)
+          ? formatMoney(values.cost_usd)
+          : "Not reported";
+      const active =
+        capabilities[provider].active_time.supported &&
+        isReported(values.active_seconds)
+          ? formatDuration(values.active_seconds)
+          : "Not reported";
+      const tokenTypes = Object.entries(values.tokens || {})
+        .map(([type, value]) => `${type} ${formatInteger(value)}`)
+        .join(", ");
+      for (const value of [
+        name,
+        node("td", "", formatInteger(values.sessions)),
+        node("td", "", formatInteger(values.total_tokens)),
+        node("td", "", tokenTypes || "Not reported"),
+        node("td", "", cost),
+        node("td", "", active),
+        node(
+          "td",
+          "",
+          values.models.length ? values.models.join(", ") : "No model data",
+        ),
+      ]) {
+        row.append(value);
+      }
+      rows.push(row);
+    }
+    elements.providerTable.replaceChildren(...rows);
+  }
+
+  function renderSeries(items) {
+    const maximum = Math.max(...items.map((item) => Number(item.value)), 1);
+    const bars = items.map((item) => {
+      const bar = node("div", `insights-bar bar-${item.provider}`);
+      const amount = Math.max(2, (Number(item.value) / maximum) * 100);
+      bar.style.setProperty("--bar-size", `${amount}%`);
+      bar.setAttribute(
+        "aria-label",
+        `${item.provider}, ${new Date(item.bucket).toLocaleString()}, ${formatInteger(item.value)} tokens`,
+      );
+      bar.append(
+        node("span", "bar-value", formatInteger(item.value)),
+        node("span", "bar-label", item.provider),
+      );
+      return bar;
+    });
+    elements.tokenChart.replaceChildren(...bars);
+    const rows = items.map((item) => {
+      const row = document.createElement("tr");
+      row.append(
+        node("td", "", new Date(item.bucket).toLocaleString()),
+        node("td", "", item.provider),
+        node("td", "", formatInteger(item.value)),
+      );
+      return row;
+    });
+    elements.tokenTable.replaceChildren(...rows);
+  }
+
+  function renderActivity(items) {
+    if (!items.length) {
+      elements.activity.replaceChildren(
+        node("li", "activity-empty", "No commits were observed in this range."),
+      );
+      return;
+    }
+    const entries = items.map((item) => {
+      const entry = node("li", "activity-item");
+      const heading = node("div", "activity-heading");
+      heading.append(
+        node("strong", "", item.repo),
+        node("time", "", new Date(item.observed_at).toLocaleString()),
+      );
+      entry.append(
+        heading,
+        node(
+          "span",
+          "activity-detail",
+          `${item.box} · +${formatInteger(item.additions)} −${formatInteger(item.deletions)} · ${formatInteger(item.files_changed)} file${item.files_changed === 1 ? "" : "s"}${item.is_merge ? " · merge" : ""}`,
+        ),
+      );
+      return entry;
+    });
+    elements.activity.replaceChildren(...entries);
+  }
+
+  function renderCollectors(items) {
+    if (!items.length) {
+      elements.collectors.replaceChildren(
+        node("li", "collector-empty", "No collector has checked in yet."),
+      );
+      return;
+    }
+    const entries = items.map((item) => {
+      const entry = node("li", "collector-item");
+      const heading = node("div", "collector-heading");
+      heading.append(
+        node("strong", "", `${item.box} · ${item.collector}`),
+        node(
+          "span",
+          `status-chip status-${item.status}`,
+          item.status.replaceAll("_", " "),
+        ),
+      );
+      const dropped = item.dropped_points
+        ? ` · ${formatInteger(item.dropped_points)} dropped points`
+        : " · no known loss";
+      entry.append(
+        heading,
+        node(
+          "span",
+          "collector-detail",
+          `${formatInteger(item.queue_bytes)} queued bytes · ${formatInteger(item.freshness_seconds)}s old${dropped}`,
+        ),
+      );
+      return entry;
+    });
+    elements.collectors.replaceChildren(...entries);
+  }
+
+  function render(summaryEnvelope, seriesEnvelope, activityEnvelope) {
+    const data = summaryEnvelope.data;
+    const totals = data.ai.totals;
+    const code = data.code;
+    elements.sessions.textContent = formatInteger(totals.sessions);
+    elements.tokens.textContent = formatInteger(totals.tokens);
+    elements.cost.textContent = !isReported(totals.provider_reported_cost_usd)
+      ? "Not reported"
+      : formatMoney(totals.provider_reported_cost_usd);
+    elements.active.textContent = !isReported(totals.active_seconds)
+      ? "Not reported"
+      : formatDuration(totals.active_seconds);
+    elements.aiLines.textContent = !isReported(totals.ai_lines)
+      ? "Not reported"
+      : formatInteger(totals.ai_lines);
+    elements.commits.textContent = formatInteger(code.commits);
+    elements.additions.textContent = formatInteger(code.additions);
+    elements.deletions.textContent = formatInteger(code.deletions);
+    const tree = code.working_tree;
+    const changed = tree.staged_files + tree.unstaged_files;
+    elements.worktree.textContent = changed
+      ? `${formatInteger(changed)} files`
+      : "Clean";
+    elements.worktreeDetail.textContent = `${formatInteger(tree.staged_files)} staged · ${formatInteger(tree.unstaged_files)} unstaged tracked files`;
+    renderCoverage(summaryEnvelope.coverage);
+    renderProviders(data.ai, summaryEnvelope.capabilities);
+    renderSeries(seriesEnvelope.data.items);
+    renderActivity(activityEnvelope.data.items);
+    renderCollectors(summaryEnvelope.coverage.collectors);
+    const hasData =
+      totals.sessions ||
+      totals.tokens ||
+      totals.provider_reported_cost_usd ||
+      totals.active_seconds ||
+      totals.ai_lines ||
+      code.commits ||
+      changed ||
+      summaryEnvelope.coverage.collectors.length;
+    elements.empty.hidden = Boolean(hasData);
+    elements.content.hidden = !hasData;
+    elements.loading.hidden = true;
+  }
+
+  async function load() {
+    elements.loading.hidden = false;
+    elements.error.hidden = true;
+    refreshButton.disabled = true;
+    try {
+      const parameters = query();
+      const seriesParameters = new URLSearchParams(parameters);
+      seriesParameters.set("metric", "tokens");
+      const [summary, series, activity] = await Promise.all([
+        api(`/api/v1/insights/summary?${parameters}`),
+        api(`/api/v1/insights/timeseries?${seriesParameters}`),
+        api(`/api/v1/insights/activity?${parameters}`),
+      ]);
+      render(summary, series, activity);
+    } catch (error) {
+      elements.loading.hidden = true;
+      elements.content.hidden = true;
+      elements.empty.hidden = true;
+      elements.error.textContent = error.message;
+      elements.error.hidden = false;
+      elements.error.focus();
+    } finally {
+      refreshButton.disabled = false;
+    }
+  }
+
+  function toggleCustomRange() {
+    const custom = elements.range.value === "custom";
+    elements.sinceField.hidden = !custom;
+    elements.untilField.hidden = !custom;
+    elements.since.required = custom;
+    elements.until.required = custom;
+  }
+
+  elements.range.addEventListener("change", toggleCustomRange);
+  elements.form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    load();
+  });
+  refreshButton.addEventListener("click", load);
+  toggleCustomRange();
+  load();
+}

--- a/controller/src/devboxes_controller/static/styles.css
+++ b/controller/src/devboxes_controller/static/styles.css
@@ -681,6 +681,28 @@ select:focus {
   color: var(--danger);
 }
 
+.status-healthy {
+  background: var(--success-soft);
+  color: var(--success);
+}
+
+.status-stale,
+.status-partial,
+.status-restart_required {
+  background: var(--warning-soft);
+  color: var(--warning);
+}
+
+.status-data_loss_detected {
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
+.status-disabled {
+  background: var(--surface-strong);
+  color: var(--muted);
+}
+
 .ssh-command {
   display: inline-block;
   max-width: 100%;
@@ -1771,6 +1793,388 @@ kbd {
 @media (max-width: 36rem) {
   .app-header .wordmark > span:last-child {
     display: none;
+  }
+}
+
+.insights-main {
+  max-width: 82rem;
+}
+
+.insights-intro {
+  margin-bottom: var(--space-6);
+}
+
+.privacy-badge {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  padding: 0.45rem 0.7rem;
+  border: 1px solid var(--success);
+  border-radius: 999px;
+  background: var(--success-soft);
+  color: var(--success);
+  font-size: 0.78rem;
+  font-weight: 720;
+}
+
+.insights-disabled,
+.insights-empty {
+  display: grid;
+  grid-template-columns: auto minmax(0, 42rem);
+  align-items: start;
+  justify-content: center;
+  gap: var(--space-5);
+  padding: var(--space-7) var(--space-5);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+}
+
+.insights-disabled p,
+.insights-empty p {
+  color: var(--muted);
+}
+
+.insights-disabled pre {
+  margin: var(--space-5) 0;
+  padding: var(--space-4);
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+}
+
+.insights-filters {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(7.5rem, 1fr)) auto;
+  align-items: end;
+  gap: var(--space-3);
+  padding: var(--space-5);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+}
+
+.insights-apply {
+  min-height: 2.7rem;
+  white-space: nowrap;
+}
+
+.coverage-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin: var(--space-5) 0 var(--space-6);
+  padding: 0.7rem 0.85rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--muted);
+  font-size: 0.84rem;
+  font-weight: 620;
+}
+
+.coverage-dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--success);
+  box-shadow: 0 0 0 3px var(--success-soft);
+}
+
+.coverage-banner[data-status="partial"] .coverage-dot,
+.coverage-banner[data-status="stale"] .coverage-dot {
+  background: var(--warning);
+  box-shadow: 0 0 0 3px var(--warning-soft);
+}
+
+.coverage-banner[data-status="empty"] .coverage-dot {
+  background: var(--line-strong);
+  box-shadow: 0 0 0 3px var(--surface-strong);
+}
+
+.insights-loading {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-3);
+}
+
+.insights-loading span {
+  min-height: 8rem;
+  border-radius: var(--radius-md);
+  background: linear-gradient(100deg, var(--surface) 20%, var(--surface-strong) 45%, var(--surface) 70%);
+  background-size: 240% 100%;
+  animation: loading-sheen 1.4s ease-in-out infinite;
+}
+
+.insights-error {
+  padding: var(--space-4);
+  border: 1px solid var(--danger);
+  border-radius: var(--radius-sm);
+  background: var(--danger-soft);
+}
+
+.insights-section-heading {
+  margin: var(--space-7) 0 var(--space-4);
+}
+
+.insights-section-heading p {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-3);
+}
+
+.metric-card {
+  min-width: 0;
+  padding: var(--space-5);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+}
+
+.metric-card > span {
+  display: block;
+  margin-bottom: var(--space-3);
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 680;
+}
+
+.metric-card strong {
+  display: block;
+  overflow: hidden;
+  margin-bottom: var(--space-2);
+  font-size: clamp(1.45rem, 3vw, 2rem);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.04em;
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.metric-card small {
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.insights-panel {
+  min-width: 0;
+  margin-top: var(--space-6);
+  padding: 0 var(--space-5) var(--space-5);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+}
+
+.insights-panel .insights-section-heading {
+  margin-top: var(--space-5);
+}
+
+.insights-table-wrap {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+}
+
+.compact-table th,
+.compact-table td {
+  padding-top: 0.7rem;
+  padding-bottom: 0.7rem;
+  font-size: 0.82rem;
+}
+
+.insights-bars {
+  display: flex;
+  min-height: 14rem;
+  align-items: flex-end;
+  gap: var(--space-2);
+  margin-bottom: var(--space-5);
+  padding: var(--space-4) var(--space-3) 0;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--line-strong);
+}
+
+.insights-bar {
+  position: relative;
+  display: flex;
+  width: max(2.2rem, calc(100% / 18));
+  min-width: 2.2rem;
+  height: var(--bar-size);
+  min-height: 1.75rem;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 0.3rem;
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+  background: var(--primary);
+  color: var(--white);
+  transition: height var(--duration) var(--ease-out);
+}
+
+.bar-claude {
+  background: var(--warning);
+}
+
+.bar-value {
+  overflow: hidden;
+  font-size: 0.65rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 720;
+  text-overflow: ellipsis;
+}
+
+.bar-label {
+  overflow: hidden;
+  font-size: 0.6rem;
+  text-overflow: ellipsis;
+  text-transform: capitalize;
+}
+
+.insights-columns {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(18rem, 0.75fr);
+  gap: var(--space-4);
+}
+
+.activity-list,
+.collector-list {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.activity-item,
+.collector-item {
+  display: grid;
+  min-width: 0;
+  gap: var(--space-2);
+  padding: var(--space-3) 0;
+  border-top: 1px solid var(--line);
+}
+
+.activity-heading,
+.collector-heading {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.activity-heading strong,
+.collector-heading strong {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 0.86rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.activity-heading time,
+.activity-detail,
+.collector-detail,
+.activity-empty,
+.collector-empty {
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.capability-note {
+  margin-top: var(--space-6);
+  padding: var(--space-5);
+  border-left: 3px solid var(--primary);
+  background: var(--primary-soft);
+}
+
+.capability-note p {
+  max-width: 76ch;
+  margin-bottom: 0;
+  color: var(--muted);
+}
+
+@keyframes loading-sheen {
+  from {
+    background-position: 100% 0;
+  }
+
+  to {
+    background-position: -100% 0;
+  }
+}
+
+@media (max-width: 72rem) {
+  .insights-filters {
+    grid-template-columns: repeat(4, minmax(8rem, 1fr));
+  }
+
+  .insights-apply {
+    width: 100%;
+  }
+}
+
+@media (max-width: 54rem) {
+  .insights-filters {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .metric-grid,
+  .insights-loading {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .insights-columns {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 42rem) {
+  #insights-refresh {
+    display: none;
+  }
+
+  .insights-filters {
+    grid-template-columns: 1fr;
+    padding: var(--space-4);
+  }
+
+  .insights-disabled,
+  .insights-empty {
+    grid-template-columns: 1fr;
+    justify-items: start;
+    padding: var(--space-5) var(--space-4);
+  }
+
+  .insights-panel {
+    padding-right: var(--space-4);
+    padding-left: var(--space-4);
+  }
+
+  .compact-table tr {
+    padding: var(--space-3);
+  }
+}
+
+@media (max-width: 25rem) {
+  .metric-grid,
+  .insights-loading {
+    grid-template-columns: 1fr;
+  }
+
+  .nav-link {
+    padding-inline: 0.38rem;
+    font-size: 0.76rem;
+  }
+
+  .header-actions .button-quiet {
+    padding-inline: 0.4rem;
+    font-size: 0.76rem;
   }
 }
 

--- a/controller/src/devboxes_controller/templates/cli_authorize.html
+++ b/controller/src/devboxes_controller/templates/cli_authorize.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="color-scheme" content="light">
     <title>Authorize Devbox CLI · Devboxes</title>
-    <link rel="icon" href="/static/favicon.svg?v=0.2.1" type="image/svg+xml">
-    <link rel="stylesheet" href="/static/styles.css?v=0.2.1">
+    <link rel="icon" href="/static/favicon.svg?v=0.3.0" type="image/svg+xml">
+    <link rel="stylesheet" href="/static/styles.css?v=0.3.0">
   </head>
   <body class="login-page">
     <main class="authorization-shell" aria-labelledby="authorization-title">

--- a/controller/src/devboxes_controller/templates/docs.html
+++ b/controller/src/devboxes_controller/templates/docs.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="color-scheme" content="light">
     <title>Documentation · Devboxes</title>
-    <link rel="icon" href="/static/favicon.svg?v=0.2.1" type="image/svg+xml">
-    <link rel="stylesheet" href="/static/styles.css?v=0.2.1">
-    <script src="/static/docs.js?v=0.2.1" defer></script>
+    <link rel="icon" href="/static/favicon.svg?v={{ version }}" type="image/svg+xml">
+    <link rel="stylesheet" href="/static/styles.css?v={{ version }}">
+    <script src="/static/docs.js?v={{ version }}" defer></script>
   </head>
   <body class="docs-page">
     <a class="skip-link" href="#main-content">Skip to documentation</a>
@@ -19,6 +19,7 @@
         </a>
         <nav class="primary-nav" aria-label="Primary navigation">
           <a class="nav-link" href="/">Workbench</a>
+          <a class="nav-link" href="/insights">Insights</a>
           <a class="nav-link" href="/docs" aria-current="page">Docs</a>
         </nav>
       </div>
@@ -40,6 +41,7 @@
             <a href="#accounts">Accounts and tools</a>
             <a href="#daily-workflow">Daily workflow</a>
             <a href="#automation">Automation</a>
+            <a href="#insights">Insights</a>
             <a href="#dashboard">Dashboard</a>
             <a href="#commands">Command reference</a>
             <a href="#troubleshooting">Troubleshooting</a>
@@ -343,6 +345,39 @@ DEVBOX_TOKEN="$TOKEN_FROM_YOUR_SECRET_STORE" \
           </dl>
         </section>
 
+        <section class="docs-section" id="insights" tabindex="-1">
+          <h2>Understand work with Insights</h2>
+          {% if insights_enabled %}
+          <p>
+            Insights is enabled for this installation. It combines privacy-bounded local metrics
+            from Codex and Claude Code with aggregate Git activity observed after each repository's
+            first scan. Open the dashboard or query the same range from your terminal.
+          </p>
+          <div class="command-block">
+            <div class="command-heading">
+              <span>Inspect metrics and collector health</span>
+              <button class="command-copy" type="button" data-copy-target="insights-command" aria-label="Copy Insights commands">Copy</button>
+            </div>
+            <pre><code id="insights-command">devbox metrics --since 7d
+devbox metrics status
+devbox metrics activity --box atlas
+devbox metrics export --format csv &gt; insights.csv</code></pre>
+          </div>
+          <p>
+            Unsupported measurements remain not reported instead of becoming zero. Insights never
+            computes a productivity score or an AI-written percentage, and it does not collect
+            prompts, responses, commands, paths, file contents, Git authors, or commit messages.
+          </p>
+          <a class="button button-primary docs-workbench-link" href="/insights">Open Insights</a>
+          {% else %}
+          <p>
+            Insights is disabled for this installation. An operator can opt in through the Helm
+            <code>insights.enabled</code> value. No workspace metrics are centrally collected while
+            it remains disabled.
+          </p>
+          {% endif %}
+        </section>
+
         <section class="docs-section" id="dashboard" tabindex="-1">
           <h2>Use the browser workbench</h2>
           <p>
@@ -379,6 +414,7 @@ DEVBOX_TOKEN="$TOKEN_FROM_YOUR_SECRET_STORE" \
                 <tr><th scope="row"><code>devbox start NAME</code></th><td>Restarts compute and renews the TTL.</td><td><code>--json</code></td></tr>
                 <tr><th scope="row"><code>devbox stop NAME</code></th><td>Frees compute while retaining the home volume.</td><td><code>--json</code></td></tr>
                 <tr><th scope="row"><code>devbox delete NAME</code></th><td>Removes compute and its SSH service.</td><td><code>--purge</code>, <code>--yes</code></td></tr>
+                <tr><th scope="row"><code>devbox metrics</code></th><td>Queries opt-in AI metrics, Git aggregates, and collector health.</td><td><code>status</code>, <code>activity</code>, <code>export</code>, <code>purge</code></td></tr>
               </tbody>
             </table>
           </div>

--- a/controller/src/devboxes_controller/templates/index.html
+++ b/controller/src/devboxes_controller/templates/index.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="color-scheme" content="light">
     <title>Devboxes</title>
-    <link rel="icon" href="/static/favicon.svg?v=0.2.1" type="image/svg+xml">
-    <link rel="stylesheet" href="/static/styles.css?v=0.2.1">
-    <script src="/static/app.js?v=0.2.1" defer></script>
+    <link rel="icon" href="/static/favicon.svg?v={{ version }}" type="image/svg+xml">
+    <link rel="stylesheet" href="/static/styles.css?v={{ version }}">
+    <script src="/static/app.js?v={{ version }}" defer></script>
   </head>
   <body>
     <a class="skip-link" href="#main-content">Skip to content</a>
@@ -19,6 +19,7 @@
         </a>
         <nav class="primary-nav" aria-label="Primary navigation">
           <a class="nav-link" href="/" aria-current="page">Workbench</a>
+          <a class="nav-link" href="/insights">Insights</a>
           <a class="nav-link" href="/docs">Docs</a>
         </nav>
       </div>

--- a/controller/src/devboxes_controller/templates/insights.html
+++ b/controller/src/devboxes_controller/templates/insights.html
@@ -1,0 +1,208 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="light">
+    <title>Insights · Devboxes</title>
+    <link rel="icon" href="/static/favicon.svg?v={{ version }}" type="image/svg+xml">
+    <link rel="stylesheet" href="/static/styles.css?v={{ version }}">
+    <script src="/static/insights.js?v={{ version }}" defer></script>
+  </head>
+  <body class="insights-page" data-insights-enabled="{{ 'true' if insights_enabled else 'false' }}">
+    <a class="skip-link" href="#main-content">Skip to Insights</a>
+    <header class="app-header">
+      <div class="header-leading">
+        <a class="wordmark" href="/" aria-label="Devboxes home">
+          <span class="wordmark-mark" aria-hidden="true">db</span>
+          <span>devboxes</span>
+        </a>
+        <nav class="primary-nav" aria-label="Primary navigation">
+          <a class="nav-link" href="/">Workbench</a>
+          <a class="nav-link" href="/insights" aria-current="page">Insights</a>
+          <a class="nav-link" href="/docs">Docs</a>
+        </nav>
+      </div>
+      <div class="header-actions">
+        <span class="cluster-state"><span aria-hidden="true"></span> {{ cluster_name }} connected</span>
+        <button class="button button-quiet" id="insights-refresh" type="button">Refresh</button>
+        <button class="button button-quiet" id="logout-button" type="button">Sign out</button>
+      </div>
+    </header>
+
+    <main class="app-main insights-main" id="main-content" tabindex="-1">
+      <section class="page-intro insights-intro" aria-labelledby="page-title">
+        <div>
+          <p class="context-line">Private by design · opt-in collection</p>
+          <h1 id="page-title">Understand the work, not the worker.</h1>
+          <p>
+            AI usage and source activity stay separate. Insights stores numeric metrics and Git
+            aggregates, never prompts, transcripts, commands, paths, authors, or file content.
+          </p>
+        </div>
+        <span class="privacy-badge">Metrics only</span>
+      </section>
+
+      {% if not insights_enabled %}
+      <section class="insights-disabled" aria-labelledby="disabled-title">
+        <div class="empty-glyph" aria-hidden="true">i</div>
+        <div>
+          <p class="context-line">Safe default</p>
+          <h2 id="disabled-title">Insights is off.</h2>
+          <p>
+            Enable it explicitly in Helm. Existing running devboxes are not restarted; they report
+            a restart-required state until their next operator-controlled restart.
+          </p>
+          <pre><code>insights:
+  enabled: true</code></pre>
+          <a class="button button-primary" href="/docs#insights">Read the privacy and operations guide</a>
+        </div>
+      </section>
+      {% else %}
+      <form class="insights-filters" id="insights-filters" aria-label="Insights filters">
+        <div class="field">
+          <label for="insights-range">Range</label>
+          <select id="insights-range" name="range">
+            <option value="24h">Last 24 hours</option>
+            <option value="7d" selected>Last 7 days</option>
+            <option value="30d">Last 30 days</option>
+            <option value="custom">Custom range</option>
+          </select>
+        </div>
+        <div class="field custom-range" id="custom-since-field" hidden>
+          <label for="insights-since">Since</label>
+          <input id="insights-since" name="since" type="datetime-local">
+        </div>
+        <div class="field custom-range" id="custom-until-field" hidden>
+          <label for="insights-until">Until</label>
+          <input id="insights-until" name="until" type="datetime-local">
+        </div>
+        <div class="field">
+          <label for="insights-box">Devbox <span>optional</span></label>
+          <input id="insights-box" name="box" type="text" maxlength="40" placeholder="all boxes">
+        </div>
+        <div class="field">
+          <label for="insights-provider">Provider</label>
+          <select id="insights-provider" name="provider">
+            <option value="">All providers</option>
+            <option value="codex">Codex</option>
+            <option value="claude">Claude</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="insights-model">Model <span>optional</span></label>
+          <input id="insights-model" name="model" type="text" maxlength="160" placeholder="all models">
+        </div>
+        <div class="field">
+          <label for="insights-repo">Repository <span>optional</span></label>
+          <input id="insights-repo" name="repo" type="text" maxlength="160" placeholder="all repositories">
+        </div>
+        <button class="button button-primary insights-apply" type="submit">Apply filters</button>
+      </form>
+
+      <div class="coverage-banner" id="coverage-banner" role="status" aria-live="polite">
+        <span class="coverage-dot" aria-hidden="true"></span>
+        <span id="coverage-copy">Loading collector coverage…</span>
+      </div>
+
+      <div class="insights-loading" id="insights-loading" aria-label="Loading Insights">
+        <span></span><span></span><span></span><span></span>
+      </div>
+      <div class="form-error insights-error" id="insights-error" role="alert" tabindex="-1" hidden></div>
+      <section class="insights-empty" id="insights-empty" hidden aria-labelledby="insights-empty-title">
+        <div class="empty-glyph" aria-hidden="true">∅</div>
+        <div>
+          <h2 id="insights-empty-title">No metrics in this range.</h2>
+          <p>Start an enabled devbox and use Codex, Claude, or Git. The first Git scan is a baseline.</p>
+        </div>
+      </section>
+
+      <div id="insights-content" hidden>
+        <section aria-labelledby="ai-summary-title">
+          <div class="section-heading insights-section-heading">
+            <div>
+              <p class="context-line">AI telemetry</p>
+              <h2 id="ai-summary-title">Usage reported by local clients</h2>
+              <p>Cost is a Claude provider estimate. Codex cost is not reported.</p>
+            </div>
+          </div>
+          <div class="metric-grid" id="ai-metric-grid">
+            <article class="metric-card"><span>Sessions</span><strong id="metric-sessions">0</strong><small>Codex uses process starts</small></article>
+            <article class="metric-card"><span>Tokens</span><strong id="metric-tokens">0</strong><small>Input and output totals</small></article>
+            <article class="metric-card"><span>Provider cost</span><strong id="metric-cost">Not reported</strong><small>Claude estimate only</small></article>
+            <article class="metric-card"><span>Active time</span><strong id="metric-active">Not reported</strong><small>Claude reported</small></article>
+            <article class="metric-card"><span>AI-modified lines</span><strong id="metric-ai-lines">Not reported</strong><small>Claude telemetry, not Git churn</small></article>
+          </div>
+        </section>
+
+        <section class="insights-panel" aria-labelledby="usage-trend-title">
+          <div class="section-heading insights-section-heading">
+            <div>
+              <h2 id="usage-trend-title">Token usage over time</h2>
+              <p>Bars and the table below represent the same values.</p>
+            </div>
+          </div>
+          <div class="insights-bars" id="token-chart" role="img" aria-label="Token usage over time"></div>
+          <div class="devbox-table-wrap insights-table-wrap">
+            <table class="devbox-table compact-table">
+              <caption class="visually-hidden">Token usage values by time and provider</caption>
+              <thead><tr><th scope="col">Period</th><th scope="col">Provider</th><th scope="col">Tokens</th></tr></thead>
+              <tbody id="token-table"></tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="insights-panel" aria-labelledby="provider-title">
+          <div class="section-heading insights-section-heading">
+            <div>
+              <h2 id="provider-title">Provider breakdown</h2>
+              <p>Unsupported values remain visibly unavailable instead of becoming zero.</p>
+            </div>
+          </div>
+          <div class="devbox-table-wrap insights-table-wrap">
+            <table class="devbox-table compact-table">
+              <thead><tr><th scope="col">Provider</th><th scope="col">Sessions</th><th scope="col">Tokens</th><th scope="col">Token types</th><th scope="col">Cost</th><th scope="col">Active time</th><th scope="col">Models</th></tr></thead>
+              <tbody id="provider-table"></tbody>
+            </table>
+          </div>
+        </section>
+
+        <section aria-labelledby="code-summary-title">
+          <div class="section-heading insights-section-heading">
+            <div>
+              <p class="context-line">Repository activity</p>
+              <h2 id="code-summary-title">Git facts, counted separately</h2>
+              <p>No author names, commit messages, paths, remotes with credentials, or file content.</p>
+            </div>
+          </div>
+          <div class="metric-grid code-metric-grid">
+            <article class="metric-card"><span>Commits observed</span><strong id="metric-commits">0</strong><small>Merges count once</small></article>
+            <article class="metric-card"><span>Lines added</span><strong id="metric-additions">0</strong><small>Text files only</small></article>
+            <article class="metric-card"><span>Lines deleted</span><strong id="metric-deletions">0</strong><small>Text files only</small></article>
+            <article class="metric-card"><span>Current worktree</span><strong id="metric-worktree">Clean</strong><small id="metric-worktree-detail">Staged plus unstaged tracked changes</small></article>
+          </div>
+        </section>
+
+        <section class="insights-columns">
+          <article class="insights-panel" aria-labelledby="activity-title">
+            <div class="section-heading insights-section-heading"><div><h2 id="activity-title">Recent activity</h2><p>Aggregate commit observations only.</p></div></div>
+            <ol class="activity-list" id="activity-list"></ol>
+          </article>
+          <article class="insights-panel" aria-labelledby="collectors-title">
+            <div class="section-heading insights-section-heading"><div><h2 id="collectors-title">Collector health</h2><p>Freshness, queue size, and known loss.</p></div></div>
+            <ul class="collector-list" id="collector-list"></ul>
+          </article>
+        </section>
+
+        <section class="capability-note" aria-labelledby="capability-title">
+          <h2 id="capability-title">What Insights cannot claim</h2>
+          <p>
+            It does not estimate Codex cost, score productivity, infer AI-written percentages, or
+            reconstruct history that the local collectors never observed.
+          </p>
+        </section>
+      </div>
+      {% endif %}
+    </main>
+  </body>
+</html>

--- a/controller/src/devboxes_controller/templates/login.html
+++ b/controller/src/devboxes_controller/templates/login.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="color-scheme" content="light">
     <title>Sign in · Devboxes</title>
-    <link rel="icon" href="/static/favicon.svg?v=0.2.1" type="image/svg+xml">
-    <link rel="stylesheet" href="/static/styles.css?v=0.2.1">
+    <link rel="icon" href="/static/favicon.svg?v=0.3.0" type="image/svg+xml">
+    <link rel="stylesheet" href="/static/styles.css?v=0.3.0">
   </head>
   <body class="login-page">
     <main class="login-shell">

--- a/controller/tests/fakes.py
+++ b/controller/tests/fakes.py
@@ -91,3 +91,6 @@ class FakeManager:
 
     async def stop_expired(self) -> list[str]:
         return []
+
+    async def reconcile_insights(self) -> list[str]:
+        return []

--- a/controller/tests/fixtures/claude-2.1.205-otlp.json
+++ b/controller/tests/fixtures/claude-2.1.205-otlp.json
@@ -1,0 +1,132 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {"key": "host.arch", "value": {"stringValue": "arm64"}},
+          {"key": "service.name", "value": {"stringValue": "claude-code"}},
+          {"key": "service.version", "value": {"stringValue": "2.1.205"}}
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "scope": {"name": "com.anthropic.claude_code", "version": "2.1.205"},
+          "metrics": [
+            {
+              "name": "claude_code.session.count",
+              "unit": "",
+              "sum": {
+                "aggregationTemporality": 1,
+                "isMonotonic": true,
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {"key": "user.id", "value": {"stringValue": "sensitive-user-hash"}},
+                      {"key": "app.version", "value": {"stringValue": "2.1.205"}},
+                      {"key": "terminal.type", "value": {"stringValue": "non-interactive"}},
+                      {"key": "start_type", "value": {"stringValue": "fresh"}}
+                    ],
+                    "startTimeUnixNano": "1784056002422000000",
+                    "timeUnixNano": "1784056002499000000",
+                    "asDouble": 1
+                  }
+                ]
+              }
+            },
+            {
+              "name": "claude_code.cost.usage",
+              "unit": "USD",
+              "sum": {
+                "aggregationTemporality": 1,
+                "isMonotonic": true,
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {"key": "user.id", "value": {"stringValue": "sensitive-user-hash"}},
+                      {"key": "model", "value": {"stringValue": "claude-sonnet-4-5-20250929"}},
+                      {"key": "query_source", "value": {"stringValue": "main"}}
+                    ],
+                    "startTimeUnixNano": "1784056002494000000",
+                    "timeUnixNano": "1784056002500000000",
+                    "asDouble": 0.0123
+                  },
+                  {
+                    "attributes": [
+                      {"key": "model", "value": {"stringValue": "claude-sonnet-4-5-20250929"}},
+                      {"key": "query_source", "value": {"stringValue": "auxiliary"}}
+                    ],
+                    "startTimeUnixNano": "1784056002489000000",
+                    "timeUnixNano": "1784056002501000000",
+                    "asDouble": 0.0123
+                  }
+                ]
+              }
+            },
+            {
+              "name": "claude_code.token.usage",
+              "unit": "tokens",
+              "sum": {
+                "aggregationTemporality": 1,
+                "isMonotonic": true,
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {"key": "model", "value": {"stringValue": "claude-sonnet-4-5-20250929"}},
+                      {"key": "query_source", "value": {"stringValue": "main"}},
+                      {"key": "type", "value": {"stringValue": "input"}}
+                    ],
+                    "startTimeUnixNano": "1784056002494000000",
+                    "timeUnixNano": "1784056002502000000",
+                    "asDouble": 12
+                  },
+                  {
+                    "attributes": [
+                      {"key": "model", "value": {"stringValue": "claude-sonnet-4-5-20250929"}},
+                      {"key": "query_source", "value": {"stringValue": "main"}},
+                      {"key": "type", "value": {"stringValue": "output"}}
+                    ],
+                    "startTimeUnixNano": "1784056002494000000",
+                    "timeUnixNano": "1784056002503000000",
+                    "asDouble": 3
+                  }
+                ]
+              }
+            },
+            {
+              "name": "claude_code.active_time.total",
+              "unit": "s",
+              "sum": {
+                "aggregationTemporality": 1,
+                "isMonotonic": true,
+                "dataPoints": [
+                  {
+                    "attributes": [{"key": "type", "value": {"stringValue": "cli"}}],
+                    "startTimeUnixNano": "1784056002497000000",
+                    "timeUnixNano": "1784056002504000000",
+                    "asDouble": 90.5
+                  }
+                ]
+              }
+            },
+            {
+              "name": "claude_code.lines_of_code.count",
+              "unit": "lines",
+              "sum": {
+                "aggregationTemporality": 1,
+                "isMonotonic": true,
+                "dataPoints": [
+                  {
+                    "attributes": [{"key": "type", "value": {"stringValue": "added"}}],
+                    "startTimeUnixNano": "1784056002497000000",
+                    "timeUnixNano": "1784056002505000000",
+                    "asDouble": 7
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/controller/tests/fixtures/codex-0.144.0-otlp.json
+++ b/controller/tests/fixtures/codex-0.144.0-otlp.json
@@ -1,0 +1,81 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {"key": "service.name", "value": {"stringValue": "codex_exec"}},
+          {"key": "service.version", "value": {"stringValue": "0.144.0"}},
+          {"key": "host.name", "value": {"stringValue": "sensitive-host"}}
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "scope": {"name": "codex_otel", "version": "0.144.0"},
+          "metrics": [
+            {
+              "name": "codex.process.start",
+              "unit": "1",
+              "sum": {
+                "aggregationTemporality": 1,
+                "isMonotonic": true,
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {"key": "auth_mode", "value": {"stringValue": "chatgpt"}},
+                      {"key": "conversation.id", "value": {"stringValue": "sensitive-session"}}
+                    ],
+                    "startTimeUnixNano": "1784056003000000000",
+                    "timeUnixNano": "1784056003100000000",
+                    "asInt": "1"
+                  }
+                ]
+              }
+            },
+            {
+              "name": "codex.turn.token_usage",
+              "unit": "tokens",
+              "histogram": {
+                "aggregationTemporality": 1,
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {"key": "model", "value": {"stringValue": "gpt-5.2-codex"}},
+                      {"key": "token_type", "value": {"stringValue": "total"}},
+                      {"key": "prompt", "value": {"stringValue": "sensitive-prompt"}}
+                    ],
+                    "startTimeUnixNano": "1784056003000000000",
+                    "timeUnixNano": "1784056003200000000",
+                    "count": "1",
+                    "sum": 42,
+                    "min": 42,
+                    "max": 42,
+                    "bucketCounts": ["0", "1"],
+                    "explicitBounds": [64]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "codex.sqlite.init.duration_ms",
+              "unit": "ms",
+              "histogram": {
+                "aggregationTemporality": 1,
+                "dataPoints": [
+                  {
+                    "attributes": [{"key": "status", "value": {"stringValue": "ok"}}],
+                    "startTimeUnixNano": "1784056003000000000",
+                    "timeUnixNano": "1784056003300000000",
+                    "count": "1",
+                    "sum": 5.5,
+                    "bucketCounts": ["1"],
+                    "explicitBounds": [10]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/controller/tests/test_app.py
+++ b/controller/tests/test_app.py
@@ -79,7 +79,7 @@ def test_browser_login_and_dashboard_session() -> None:
         assert dashboard.headers["x-content-type-options"] == "nosniff"
         assert "Kubernetes connected" in dashboard.text
         assert "cluster default storage" in dashboard.text
-        styles = client.get("/static/styles.css?v=0.2.1")
+        styles = client.get("/static/styles.css?v=0.3.0")
         assert "[hidden]" in styles.text
         assert "display: none !important" in styles.text
         payload = client.get("/api/v1/devboxes").json()

--- a/controller/tests/test_auth.py
+++ b/controller/tests/test_auth.py
@@ -248,3 +248,19 @@ def test_default_signing_key_is_derived_and_rotation_revokes_tokens() -> None:
     assert expires_in == 2_592_000
     assert same.validate_cli_token(token) == "operator"
     assert rotated.validate_cli_token(token) is None
+
+
+def test_insights_tokens_are_instance_scoped_domain_separated_and_rotatable() -> None:
+    instance_id = "99999999-9999-4999-8999-999999999999"
+    first = Authenticator(settings(insights_signing_key=None))
+    same = Authenticator(settings(insights_signing_key=None))
+    rotated = Authenticator(settings(insights_signing_key="r" * 32))
+
+    token = first.issue_insights_token(instance_id, "atlas")
+    cli_token, _ = first.issue_cli_token("operator")
+
+    assert same.validate_insights_token(token) == (instance_id, "atlas")
+    assert rotated.validate_insights_token(token) is None
+    assert first.validate_insights_token(token.replace("atlas", "other")) is None
+    assert first.validate_insights_token(cli_token) is None
+    assert MASTER_TOKEN not in token

--- a/controller/tests/test_insights_app.py
+++ b/controller/tests/test_insights_app.py
@@ -1,0 +1,230 @@
+import gzip
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from devboxes_controller.app import create_app
+from devboxes_controller.auth import Authenticator
+from devboxes_controller.config import Settings
+from devboxes_controller.insights_service import InsightsService
+
+from .fakes import FakeManager
+from .test_app import browser_login
+
+FIXTURES = Path(__file__).parent / "fixtures"
+INSTANCE = "88888888-8888-4888-8888-888888888888"
+MASTER_TOKEN = "test-access-token-at-least-32-characters"
+
+
+def enabled_app(tmp_path: Path) -> tuple[TestClient, Settings]:
+    settings = Settings(
+        access_token=MASTER_TOKEN,
+        cookie_secure=False,
+        cleanup_interval_seconds=3600,
+        insights_enabled=True,
+        insights_db_path=str(tmp_path / "insights.db"),
+    )
+    service = InsightsService(settings)
+    return TestClient(create_app(settings, FakeManager(), service)), settings  # type: ignore[arg-type]
+
+
+def otlp_batch(batch_id: str = "a" * 64) -> bytes:
+    return json.dumps(
+        {
+            "schema_version": 1,
+            "batch_id": batch_id,
+            "sent_at": datetime.now(UTC).isoformat(),
+            "collector": "otel",
+            "kind": "otlp",
+            "payload": json.loads((FIXTURES / "claude-2.1.205-otlp.json").read_text()),
+        }
+    ).encode()
+
+
+def test_insights_dashboard_disabled_state_and_read_contract() -> None:
+    settings = Settings(
+        access_token=MASTER_TOKEN,
+        cookie_secure=False,
+        cleanup_interval_seconds=3600,
+    )
+    with TestClient(create_app(settings, FakeManager())) as client:  # type: ignore[arg-type]
+        browser_login(client)
+        dashboard = client.get("/insights")
+        assert dashboard.status_code == 200
+        assert "Insights is off" in dashboard.text
+        assert 'aria-current="page">Insights' in dashboard.text
+        assert 'data-insights-enabled="false"' in dashboard.text
+
+        headers = {"Authorization": f"Bearer {MASTER_TOKEN}"}
+        summary = client.get("/api/v1/insights/summary", headers=headers)
+        assert summary.status_code == 200
+        assert summary.json()["enabled"] is False
+        assert summary.json()["coverage"]["status"] == "disabled"
+        assert client.get("/api/v1/insights/capabilities", headers=headers).status_code == 200
+        assert client.post("/internal/v1/insights/batches", content=b"{}").status_code == 404
+        assert client.delete("/api/v1/insights/devboxes/atlas", headers=headers).status_code == 409
+
+
+def test_authenticated_ingest_drives_summary_series_export_and_purge(tmp_path: Path) -> None:
+    client, settings = enabled_app(tmp_path)
+    credential = Authenticator(settings).issue_insights_token(INSTANCE, "atlas")
+    ingest_headers = {
+        "Authorization": f"Bearer {credential}",
+        "Content-Type": "application/json",
+        "Content-Encoding": "gzip",
+    }
+    api_headers = {"Authorization": f"Bearer {MASTER_TOKEN}"}
+    with client:
+        accepted = client.post(
+            "/internal/v1/insights/batches",
+            content=gzip.compress(otlp_batch()),
+            headers=ingest_headers,
+        )
+        assert accepted.status_code == 200
+        assert accepted.json() == {"accepted": True, "duplicate": False, "points": 7}
+
+        duplicate = client.post(
+            "/internal/v1/insights/batches",
+            content=gzip.compress(otlp_batch()),
+            headers=ingest_headers,
+        )
+        assert duplicate.json()["duplicate"] is True
+
+        summary = client.get("/api/v1/insights/summary?since=24h", headers=api_headers)
+        assert summary.status_code == 200
+        assert summary.json()["data"]["ai"]["totals"]["tokens"] == 15
+        grouped = client.get(
+            f"/api/v1/insights/summary?since=24h&devbox=atlas&instance_id={INSTANCE}"
+            "&group_by=provider",
+            headers=api_headers,
+        )
+        assert grouped.status_code == 200
+        assert grouped.json()["data"]["groups"][0]["key"] == "claude"
+        assert grouped.json()["storage"]["database_bytes"] > 0
+        series = client.get(
+            "/api/v1/insights/timeseries?metric=tokens&since=24h",
+            headers=api_headers,
+        )
+        assert series.status_code == 200
+        assert series.json()["data"]["items"]
+        assert (
+            client.get(
+                "/api/v1/insights/timeseries?metric=productivity_score",
+                headers=api_headers,
+            ).status_code
+            == 422
+        )
+        assert client.get("/api/v1/insights/activity", headers=api_headers).status_code == 200
+        capabilities = client.get("/api/v1/insights/capabilities", headers=api_headers)
+        assert capabilities.json()["capabilities"]["codex"]["cost"]["supported"] is False
+
+        exported_json = client.get("/api/v1/insights/export?format=json", headers=api_headers)
+        assert exported_json.status_code == 200
+        assert exported_json.headers["content-type"].startswith("application/json")
+        exported_csv = client.get("/api/v1/insights/export?format=csv", headers=api_headers)
+        assert exported_csv.status_code == 200
+        assert exported_csv.text.startswith("category,provider,metric,value\n")
+        assert "sensitive-user-hash" not in exported_csv.text
+        exported_sqlite = client.get("/api/v1/insights/export?format=sqlite", headers=api_headers)
+        assert exported_sqlite.status_code == 200
+        assert exported_sqlite.content.startswith(b"SQLite format 3\x00")
+
+        browser_login(client)
+        dashboard = client.get("/insights")
+        assert "Understand the work, not the worker" in dashboard.text
+        assert 'data-insights-enabled="true"' in dashboard.text
+        csrf = client.cookies.get("devboxes_csrf")
+        purged = client.delete(
+            "/api/v1/insights?box=atlas",
+            headers={"X-Devboxes-CSRF": csrf},
+        )
+        assert purged.status_code == 200
+        assert purged.json()["purged_instances"] == 1
+
+
+def test_ingest_endpoint_accepts_only_scoped_metrics_json(tmp_path: Path) -> None:
+    client, settings = enabled_app(tmp_path)
+    credential = Authenticator(settings).issue_insights_token(INSTANCE, "atlas")
+    with client:
+        assert (
+            client.post(
+                "/internal/v1/insights/batches",
+                content=otlp_batch(),
+                headers={"Content-Type": "application/json"},
+            ).status_code
+            == 401
+        )
+        assert (
+            client.post(
+                "/internal/v1/insights/batches",
+                content=otlp_batch(),
+                headers={
+                    "Authorization": f"Bearer {MASTER_TOKEN}",
+                    "Content-Type": "application/json",
+                },
+            ).status_code
+            == 401
+        )
+        assert (
+            client.post(
+                "/internal/v1/insights/batches",
+                content=otlp_batch(),
+                headers={
+                    "Authorization": f"Bearer {credential}",
+                    "Content-Type": "text/plain",
+                },
+            ).status_code
+            == 415
+        )
+        invalid = client.post(
+            "/internal/v1/insights/batches",
+            content=b'{"private":"do-not-reflect"}',
+            headers={
+                "Authorization": f"Bearer {credential}",
+                "Content-Type": "application/json",
+            },
+        )
+        assert invalid.status_code == 400
+        assert "do-not-reflect" not in invalid.text
+        wrong_instance = json.loads(otlp_batch())
+        wrong_instance["instance_id"] = "99999999-9999-4999-8999-999999999999"
+        rejected = client.post(
+            "/internal/v1/insights/batches",
+            content=json.dumps(wrong_instance).encode(),
+            headers={
+                "Authorization": f"Bearer {credential}",
+                "Content-Type": "application/json",
+            },
+        )
+        assert rejected.status_code == 400
+
+
+def test_insights_query_validation_and_authentication(tmp_path: Path) -> None:
+    client, _ = enabled_app(tmp_path)
+    headers = {"Authorization": f"Bearer {MASTER_TOKEN}"}
+    with client:
+        assert client.get("/api/v1/insights/summary").status_code == 401
+        assert (
+            client.get("/api/v1/insights/summary?since=1000d", headers=headers).status_code == 422
+        )
+        assert (
+            client.get("/api/v1/insights/activity?cursor=invalid", headers=headers).status_code
+            == 422
+        )
+        assert (
+            client.get(
+                "/api/v1/insights/summary?box=atlas&devbox=other",
+                headers=headers,
+            ).status_code
+            == 422
+        )
+        assert (
+            client.get(
+                "/api/v1/insights/summary?instance_id=not-a-uuid",
+                headers=headers,
+            ).status_code
+            == 422
+        )
+        assert client.delete("/api/v1/insights", headers=headers).status_code == 422

--- a/controller/tests/test_insights_privacy.py
+++ b/controller/tests/test_insights_privacy.py
@@ -1,0 +1,254 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from devboxes_controller.insights_privacy import (
+    InsightsPayloadError,
+    contains_sensitive_key,
+    sanitize_git_payload,
+    sanitize_otlp,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def fixture(name: str) -> dict[str, object]:
+    return json.loads((FIXTURES / name).read_text())
+
+
+@pytest.mark.parametrize(
+    "name,points",
+    [
+        ("claude-2.1.205-otlp.json", 7),
+        ("codex-0.144.0-otlp.json", 3),
+    ],
+)
+def test_provider_fixtures_are_metrics_only(name: str, points: int) -> None:
+    sanitized, point_count = sanitize_otlp(fixture(name), maximum_points=100)
+    serialized = json.dumps(sanitized, sort_keys=True)
+
+    assert point_count == points
+    assert "sensitive" not in serialized
+    assert "user.id" not in serialized
+    assert "host.name" not in serialized
+    assert "prompt" not in serialized
+    assert "session_source" in serialized if name.startswith("claude") else True
+    assert "service.version" in serialized
+
+
+def test_all_otlp_json_point_forms_preserve_only_numeric_shape() -> None:
+    common = {
+        "attributes": [
+            {"key": "model", "value": {"stringValue": "safe-model"}},
+            {"key": "command", "value": {"stringValue": "rm-sensitive"}},
+            {"key": "success", "value": {"boolValue": True}},
+        ],
+        "startTimeUnixNano": "1784056003000000000",
+        "timeUnixNano": "1784056003300000000",
+    }
+    payload = {
+        "resourceMetrics": [
+            {
+                "resource": {
+                    "attributes": [
+                        {"key": "service.name", "value": {"stringValue": "custom-client"}},
+                        {"key": "host.name", "value": {"stringValue": "private-host"}},
+                    ]
+                },
+                "scopeMetrics": [
+                    {
+                        "scope": {"name": "scope", "version": "1"},
+                        "metrics": [
+                            {
+                                "name": "safe.gauge",
+                                "gauge": {"dataPoints": [{**common, "asInt": "2"}]},
+                            },
+                            {
+                                "name": "safe.exponential",
+                                "exponentialHistogram": {
+                                    "aggregationTemporality": "2",
+                                    "dataPoints": [
+                                        {
+                                            **common,
+                                            "count": "3",
+                                            "sum": 4.5,
+                                            "scale": 2,
+                                            "zeroCount": "1",
+                                            "positive": {"offset": -1, "bucketCounts": ["1", "2"]},
+                                            "negative": {"offset": 0, "bucketCounts": []},
+                                            "exemplars": [{"traceId": "secret"}],
+                                        }
+                                    ],
+                                },
+                            },
+                            {
+                                "name": "safe.summary",
+                                "summary": {
+                                    "dataPoints": [
+                                        {
+                                            **common,
+                                            "count": "2",
+                                            "sum": 9,
+                                            "quantileValues": [
+                                                {"quantile": 0.5, "value": 4},
+                                                {"quantile": 0.9, "value": 5},
+                                            ],
+                                        }
+                                    ]
+                                },
+                            },
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+    sanitized, count = sanitize_otlp(payload, maximum_points=3)
+    serialized = json.dumps(sanitized)
+
+    assert count == 3
+    assert '"aggregationTemporality": 2' in serialized
+    assert "bucketCounts" in serialized
+    assert "quantileValues" in serialized
+    assert "private-host" not in serialized
+    assert "rm-sensitive" not in serialized
+    assert "exemplars" not in serialized
+
+
+@pytest.mark.parametrize(
+    "payload,message",
+    [
+        (None, "invalid OTLP"),
+        ({}, "invalid OTLP"),
+        ({"resourceMetrics": [None]}, "invalid OTLP"),
+        ({"resourceMetrics": [{"scopeMetrics": [None]}]}, "invalid OTLP"),
+        (
+            {"resourceMetrics": [{"scopeMetrics": [{"metrics": [{"name": "bad name"}]}]}]},
+            "invalid metric name",
+        ),
+        (
+            {
+                "resourceMetrics": [
+                    {
+                        "scopeMetrics": [
+                            {"metrics": [{"name": "safe", "gauge": {"dataPoints": [{}]}}]}
+                        ]
+                    }
+                ]
+            },
+            "no numeric value",
+        ),
+    ],
+)
+def test_invalid_otlp_is_rejected_without_reflection(payload: object, message: str) -> None:
+    with pytest.raises(InsightsPayloadError, match=message):
+        sanitize_otlp(payload, maximum_points=10)
+
+
+def test_otlp_point_count_is_bounded() -> None:
+    with pytest.raises(InsightsPayloadError, match="too many"):
+        sanitize_otlp(fixture("codex-0.144.0-otlp.json"), maximum_points=2)
+
+
+def test_git_payload_is_aggregate_only_and_bounded() -> None:
+    payload = {
+        "repositories": [
+            {
+                "repo_key": "github.com/example/repository",
+                "commits": [
+                    {
+                        "sha": "a" * 40,
+                        "committed_at": "2026-07-14T18:00:00+00:00",
+                        "additions": 12,
+                        "deletions": 4,
+                        "files_changed": 3,
+                        "binary_files": 1,
+                        "is_merge": True,
+                        "message": "must disappear",
+                    }
+                ],
+                "working_tree": {
+                    "staged_additions": 1,
+                    "staged_deletions": 2,
+                    "staged_files": 1,
+                    "unstaged_additions": 3,
+                    "unstaged_deletions": 4,
+                    "unstaged_files": 2,
+                    "binary_files": 0,
+                    "path": "must disappear",
+                },
+            }
+        ]
+    }
+    sanitized = sanitize_git_payload(payload, maximum_commits=1)
+    serialized = json.dumps(sanitized)
+
+    assert sanitized["repositories"][0]["commits"][0]["is_merge"] is True
+    assert "message" not in serialized
+    assert "path" not in serialized
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"repositories": [None]},
+        {"repositories": [{"repo_key": "bad repo", "commits": []}]},
+        {"repositories": [{"repo_key": "local-safe", "commits": [{"sha": "bad"}]}]},
+        {
+            "repositories": [
+                {
+                    "repo_key": "local-safe",
+                    "commits": [],
+                    "working_tree": {"staged_additions": -1},
+                }
+            ]
+        },
+        {
+            "repositories": [
+                {
+                    "repo_key": "local-safe",
+                    "commits": [
+                        {
+                            "sha": "a" * 40,
+                            "committed_at": "not-a-timestamp",
+                            "additions": 0,
+                            "deletions": 0,
+                            "files_changed": 0,
+                            "binary_files": 0,
+                            "is_merge": False,
+                        }
+                    ],
+                }
+            ]
+        },
+        {
+            "repositories": [
+                {
+                    "repo_key": "local-safe",
+                    "commits": [
+                        {
+                            "sha": "a" * 40,
+                            "committed_at": "2026-07-14T18:00:00+00:00",
+                            "additions": 0,
+                            "deletions": 0,
+                            "files_changed": 0,
+                            "binary_files": 0,
+                            "is_merge": "true",
+                        }
+                    ],
+                }
+            ]
+        },
+    ],
+)
+def test_invalid_git_payloads_are_rejected(payload: object) -> None:
+    with pytest.raises(InsightsPayloadError):
+        sanitize_git_payload(payload)
+
+
+def test_sensitive_key_detector_finds_nested_content() -> None:
+    assert contains_sensitive_key({"safe": [{"request_body": "secret"}]}) is True
+    assert contains_sensitive_key({"metric": [{"value": 2}]}) is False

--- a/controller/tests/test_insights_service.py
+++ b/controller/tests/test_insights_service.py
@@ -1,0 +1,351 @@
+import asyncio
+import gzip
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from devboxes_controller.config import Settings
+from devboxes_controller.insights_privacy import InsightsPayloadError
+from devboxes_controller.insights_service import (
+    InsightsDisabledError,
+    InsightsRateLimitError,
+    InsightsService,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+INSTANCE = "77777777-7777-4777-8777-777777777777"
+
+
+def settings(tmp_path: Path, **overrides: object) -> Settings:
+    return Settings(
+        access_token="test-access-token-at-least-32-characters",
+        insights_enabled=True,
+        insights_db_path=str(tmp_path / "insights.db"),
+        **overrides,
+    )
+
+
+def batch(
+    payload: object,
+    *,
+    kind: str = "otlp",
+    collector: str = "otel",
+    batch_id: str = "a" * 64,
+    **metadata: object,
+) -> bytes:
+    return json.dumps(
+        {
+            "schema_version": 1,
+            "batch_id": batch_id,
+            "sent_at": "2026-07-14T19:20:00+00:00",
+            "collector": collector,
+            "kind": kind,
+            "payload": payload,
+            **metadata,
+        }
+    ).encode()
+
+
+def test_disabled_service_is_ready_but_rejects_insights_operations(tmp_path: Path) -> None:
+    service = InsightsService(Settings(access_token="test-access-token-at-least-32-characters"))
+    asyncio.run(service.initialize())
+
+    assert asyncio.run(service.ready()) is True
+    envelope = service.disabled_envelope()
+    assert envelope["enabled"] is False
+    assert envelope["coverage"]["status"] == "disabled"
+    assert envelope["capabilities"]["codex"]["cost"]["supported"] is False
+    with pytest.raises(InsightsDisabledError):
+        asyncio.run(
+            service.ingest(
+                instance_id=INSTANCE,
+                box_name="atlas",
+                compressed_body=b"{}",
+                content_encoding=None,
+            )
+        )
+    with pytest.raises(InsightsDisabledError):
+        asyncio.run(service.purge("atlas"))
+    with pytest.raises(InsightsDisabledError):
+        asyncio.run(service.maintain())
+
+
+def test_service_ingests_gzip_and_builds_all_query_envelopes(tmp_path: Path) -> None:
+    service = InsightsService(settings(tmp_path))
+    asyncio.run(service.initialize())
+    raw = json.loads((FIXTURES / "claude-2.1.205-otlp.json").read_text())
+    encoded = batch(
+        raw,
+        collector_version="1.0",
+        queue_bytes=42,
+        dropped_points=3,
+        status="degraded",
+        capability_reason="queue loss detected",
+    )
+
+    result = asyncio.run(
+        service.ingest(
+            instance_id=INSTANCE,
+            box_name="atlas",
+            compressed_body=gzip.compress(encoded),
+            content_encoding="gzip",
+        )
+    )
+    duplicate = asyncio.run(
+        service.ingest(
+            instance_id=INSTANCE,
+            box_name="atlas",
+            compressed_body=encoded,
+            content_encoding="identity",
+        )
+    )
+    assert result == {"accepted": True, "duplicate": False, "points": 7}
+    assert duplicate["duplicate"] is True
+    assert asyncio.run(service.ready()) is True
+
+    filters = service.filters(
+        since="7d",
+        until=None,
+        box=None,
+        provider=None,
+        model=None,
+        repo=None,
+        maximum_days=365,
+    )
+    summary = asyncio.run(service.summary(filters))
+    assert summary["schema_version"] == 1
+    assert summary["enabled"] is True
+    assert summary["coverage"]["status"] == "partial"
+    assert summary["data"]["ai"]["totals"]["tokens"] == 15
+    assert summary["capabilities"]["codex"]["cost"]["reason"].startswith("Not reported")
+
+    series = asyncio.run(service.timeseries(filters, "tokens"))
+    assert series["data"]["metric"] == "tokens"
+    assert series["data"]["items"]
+    activity = asyncio.run(service.activity(filters, cursor=None, limit=10))
+    assert activity["data"]["items"] == []
+    status = asyncio.run(service.status(filters))
+    assert status["data"]["collectors"][0]["queue_bytes"] == 42
+    assert asyncio.run(service.purge("atlas"))["purged_instances"] == 1
+    assert asyncio.run(service.maintain())["raw_points"] == 0
+
+
+def test_service_ingests_git_and_heartbeat_batches(tmp_path: Path) -> None:
+    service = InsightsService(settings(tmp_path))
+    asyncio.run(service.initialize())
+    git_payload = {
+        "repositories": [
+            {
+                "repo_key": "github.com/example/project",
+                "commits": [
+                    {
+                        "sha": "c" * 40,
+                        "committed_at": "2026-07-14T19:00:00+00:00",
+                        "additions": 3,
+                        "deletions": 1,
+                        "files_changed": 1,
+                        "binary_files": 0,
+                        "is_merge": False,
+                    }
+                ],
+                "working_tree": {
+                    "staged_additions": 0,
+                    "staged_deletions": 0,
+                    "staged_files": 0,
+                    "unstaged_additions": 0,
+                    "unstaged_deletions": 0,
+                    "unstaged_files": 0,
+                    "binary_files": 0,
+                },
+            }
+        ]
+    }
+    git_result = asyncio.run(
+        service.ingest(
+            instance_id=INSTANCE,
+            box_name="atlas",
+            compressed_body=batch(
+                git_payload,
+                kind="git",
+                collector="git",
+                batch_id="b" * 64,
+            ),
+            content_encoding=None,
+        )
+    )
+    heartbeat_result = asyncio.run(
+        service.ingest(
+            instance_id=INSTANCE,
+            box_name="atlas",
+            compressed_body=batch(
+                {"observed_at": "2026-07-14T19:20:00+00:00"},
+                kind="heartbeat",
+                collector="agent",
+                batch_id="c" * 64,
+                status="not-safe",
+                capability_reason="a private path",
+            ),
+            content_encoding=None,
+        )
+    )
+    assert git_result["accepted"] is True
+    assert heartbeat_result["points"] == 0
+
+
+@pytest.mark.parametrize(
+    "since,until,maximum,message",
+    [
+        ("bad", None, 365, "timestamp"),
+        ("2020-01-02T00:00:00Z", "2020-01-01T00:00:00Z", 365, "earlier"),
+        ("100d", None, 30, "cannot exceed"),
+        ("2026-07-14T19:00:00", None, 365, "timezone"),
+    ],
+)
+def test_filter_validation(
+    tmp_path: Path,
+    since: str,
+    until: str | None,
+    maximum: int,
+    message: str,
+) -> None:
+    service = InsightsService(settings(tmp_path))
+    with pytest.raises((InsightsPayloadError, ValueError), match=message):
+        service.filters(
+            since=since,
+            until=until,
+            box="atlas",
+            provider="claude",
+            model="model",
+            repo="github.com/example/project",
+            maximum_days=maximum,
+        )
+
+
+def test_absolute_filter_dimensions_are_preserved(tmp_path: Path) -> None:
+    service = InsightsService(settings(tmp_path))
+    result = service.filters(
+        since="2026-07-13T00:00:00Z",
+        until="2026-07-14T00:00:00Z",
+        box="atlas",
+        provider="codex",
+        model="gpt-5.2-codex",
+        repo="github.com/example/project",
+        maximum_days=10,
+    )
+    assert result.since.tzinfo == UTC
+    assert result.box == "atlas"
+    assert result.provider == "codex"
+    assert result.model == "gpt-5.2-codex"
+    assert result.repo == "github.com/example/project"
+
+
+@pytest.mark.parametrize(
+    "encoded,encoding,message",
+    [
+        (b"not-json", None, "JSON"),
+        (b"not-gzip", "gzip", "compressed"),
+        (b"{}", "br", "encoding"),
+        (json.dumps([]).encode(), None, "envelope"),
+        (json.dumps({"schema_version": 1}).encode(), None, "envelope"),
+    ],
+)
+def test_batch_decode_rejects_malformed_transport(
+    tmp_path: Path, encoded: bytes, encoding: str | None, message: str
+) -> None:
+    service = InsightsService(settings(tmp_path))
+    asyncio.run(service.initialize())
+    with pytest.raises(InsightsPayloadError, match=message):
+        asyncio.run(
+            service.ingest(
+                instance_id=INSTANCE,
+                box_name="atlas",
+                compressed_body=encoded,
+                content_encoding=encoding,
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "mutations,message",
+    [
+        ({"schema_version": 2}, "schema"),
+        ({"batch_id": "short"}, "identifier"),
+        ({"collector": "agent"}, "type"),
+        ({"sent_at": "2030-01-01T00:00:00Z"}, "outside"),
+        ({"extra": "field"}, "envelope"),
+    ],
+)
+def test_batch_envelope_contract_is_strict(
+    tmp_path: Path, mutations: dict[str, object], message: str
+) -> None:
+    service = InsightsService(settings(tmp_path))
+    asyncio.run(service.initialize())
+    raw = json.loads((FIXTURES / "codex-0.144.0-otlp.json").read_text())
+    candidate = json.loads(batch(raw))
+    candidate.update(mutations)
+    with pytest.raises(InsightsPayloadError, match=message):
+        asyncio.run(
+            service.ingest(
+                instance_id=INSTANCE,
+                box_name="atlas",
+                compressed_body=json.dumps(candidate).encode(),
+                content_encoding=None,
+            )
+        )
+
+
+def test_body_size_point_count_rate_and_metric_are_bounded(tmp_path: Path) -> None:
+    service = InsightsService(
+        settings(
+            tmp_path,
+            insights_max_compressed_bytes=1024,
+            insights_max_expanded_bytes=4096,
+            insights_max_points_per_batch=2,
+            insights_ingest_rate_per_minute=1,
+        )
+    )
+    asyncio.run(service.initialize())
+    with pytest.raises(InsightsPayloadError, match="compressed"):
+        asyncio.run(
+            service.ingest(
+                instance_id=INSTANCE,
+                box_name="atlas",
+                compressed_body=b"x" * 1025,
+                content_encoding=None,
+            )
+        )
+
+    second = InsightsService(settings(tmp_path / "other", insights_ingest_rate_per_minute=1))
+    asyncio.run(second.initialize())
+    asyncio.run(second.check_rate(INSTANCE))
+    with pytest.raises(InsightsRateLimitError):
+        asyncio.run(second.check_rate(INSTANCE))
+
+    filters = second.filters(
+        since="1h",
+        until=None,
+        box=None,
+        provider=None,
+        model=None,
+        repo=None,
+        maximum_days=1,
+    )
+    with pytest.raises(ValueError, match="unsupported"):
+        asyncio.run(second.timeseries(filters, "productivity_score"))
+
+
+def test_future_filter_is_rejected(tmp_path: Path) -> None:
+    service = InsightsService(settings(tmp_path))
+    future = (datetime.now(UTC) + timedelta(days=1)).isoformat()
+    with pytest.raises(ValueError, match="future"):
+        service.filters(
+            since="1h",
+            until=future,
+            box=None,
+            provider=None,
+            model=None,
+            repo=None,
+            maximum_days=1,
+        )

--- a/controller/tests/test_insights_store.py
+++ b/controller/tests/test_insights_store.py
@@ -1,0 +1,469 @@
+import asyncio
+import json
+import sqlite3
+from contextlib import closing
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from devboxes_controller.insights_privacy import sanitize_git_payload, sanitize_otlp
+from devboxes_controller.insights_store import InsightsStore, QueryFilters
+
+FIXTURES = Path(__file__).parent / "fixtures"
+RANGE = QueryFilters(
+    since=datetime(2026, 7, 14, 18, tzinfo=UTC),
+    until=datetime(2026, 7, 14, 21, tzinfo=UTC),
+)
+
+
+def provider_fixture(name: str) -> tuple[dict[str, object], int]:
+    raw = json.loads((FIXTURES / name).read_text())
+    return sanitize_otlp(raw, maximum_points=100)
+
+
+def ingest(
+    store: InsightsStore,
+    *,
+    instance_id: str,
+    box: str,
+    batch_id: str,
+    collector: str,
+    kind: str,
+    payload: dict[str, object],
+    points: int,
+):
+    return asyncio.run(
+        store.ingest(
+            instance_id=instance_id,
+            box_name=box,
+            batch_id=batch_id,
+            collector=collector,
+            kind=kind,
+            sent_at=datetime(2026, 7, 14, 19, 10, tzinfo=UTC),
+            payload=payload,
+            reported_points=points,
+        )
+    )
+
+
+def test_store_migrates_readies_and_creates_an_online_backup(tmp_path: Path) -> None:
+    store = InsightsStore(tmp_path / "data" / "insights.db")
+    asyncio.run(store.initialize())
+
+    assert asyncio.run(store.ready()) is True
+    connection = sqlite3.connect(store.path)
+    try:
+        assert connection.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
+        assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 0
+        tables = {
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        assert {
+            "schema_migrations",
+            "devbox_instances",
+            "collectors",
+            "ingest_batches",
+            "metric_series",
+            "metric_points",
+            "metric_rollups_hourly",
+            "metric_rollups_daily",
+            "repositories",
+            "code_commits",
+            "working_tree_snapshots",
+        }.issubset(tables)
+    finally:
+        connection.close()
+
+    backup = tmp_path / "backup" / "snapshot.db"
+    asyncio.run(store.backup(backup))
+    assert backup.exists()
+    with closing(sqlite3.connect(backup)) as copy:
+        assert copy.execute("SELECT MAX(version) FROM schema_migrations").fetchone()[0] == 1
+
+
+def test_store_migrates_a_previous_empty_schema_transactionally(tmp_path: Path) -> None:
+    database = tmp_path / "insights.db"
+    with closing(sqlite3.connect(database)) as connection:
+        connection.execute(
+            "CREATE TABLE schema_migrations(version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL)"
+        )
+        connection.execute(
+            "INSERT INTO schema_migrations(version, applied_at) VALUES (0, '2026-01-01T00:00:00Z')"
+        )
+        connection.commit()
+
+    store = InsightsStore(database)
+    asyncio.run(store.initialize())
+
+    assert asyncio.run(store.ready()) is True
+    with closing(sqlite3.connect(database)) as connection:
+        assert connection.execute("SELECT MAX(version) FROM schema_migrations").fetchone()[0] == 1
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM sqlite_master "
+                "WHERE type='table' AND name='metric_rollups_daily'"
+            ).fetchone()[0]
+            == 1
+        )
+
+
+def test_provider_ingest_is_idempotent_and_queries_stable_totals(tmp_path: Path) -> None:
+    store = InsightsStore(tmp_path / "insights.db")
+    asyncio.run(store.initialize())
+    claude, claude_points = provider_fixture("claude-2.1.205-otlp.json")
+    codex, codex_points = provider_fixture("codex-0.144.0-otlp.json")
+
+    claude_result = ingest(
+        store,
+        instance_id="11111111-1111-4111-8111-111111111111",
+        box="atlas",
+        batch_id="a" * 64,
+        collector="otel",
+        kind="otlp",
+        payload=claude,
+        points=claude_points,
+    )
+    codex_result = ingest(
+        store,
+        instance_id="22222222-2222-4222-8222-222222222222",
+        box="compiler",
+        batch_id="b" * 64,
+        collector="otel",
+        kind="otlp",
+        payload=codex,
+        points=codex_points,
+    )
+    duplicate = ingest(
+        store,
+        instance_id="11111111-1111-4111-8111-111111111111",
+        box="atlas",
+        batch_id="a" * 64,
+        collector="otel",
+        kind="otlp",
+        payload=claude,
+        points=claude_points,
+    )
+    with pytest.raises(ValueError, match="conflicts"):
+        ingest(
+            store,
+            instance_id="33333333-3333-4333-8333-333333333333",
+            box="other",
+            batch_id="a" * 64,
+            collector="otel",
+            kind="otlp",
+            payload=claude,
+            points=claude_points,
+        )
+
+    assert claude_result.accepted is True
+    assert claude_result.providers == ("claude",)
+    assert codex_result.points == 3
+    assert duplicate.duplicate is True
+    assert duplicate.accepted is False
+
+    summary = asyncio.run(store.summary(RANGE))
+    assert summary["ai"]["totals"] == {
+        "sessions": 2,
+        "tokens": 57,
+        "provider_reported_cost_usd": pytest.approx(0.0123),
+        "active_seconds": pytest.approx(90.5),
+        "ai_lines": 7,
+    }
+    assert summary["ai"]["providers"]["codex"]["cost_usd"] is None
+    assert summary["ai"]["providers"]["codex"]["total_tokens"] == 42
+    assert summary["ai"]["providers"]["claude"]["total_tokens"] == 15
+    assert isinstance(summary["ai"]["providers"]["codex"]["total_tokens"], int)
+    assert isinstance(summary["ai"]["providers"]["claude"]["total_tokens"], int)
+    assert summary["ai"]["providers"]["claude"]["cost_usd"] == pytest.approx(0.0123)
+
+    series = asyncio.run(store.timeseries(RANGE, "tokens"))
+    assert {item["provider"] for item in series} == {"codex", "claude"}
+    assert sum(item["value"] for item in series) == pytest.approx(57)
+    assert asyncio.run(store.timeseries(RANGE, "sessions"))
+    assert asyncio.run(store.timeseries(RANGE, "cost"))[0]["provider"] == "claude"
+    assert asyncio.run(store.timeseries(RANGE, "active_time"))[0]["value"] == 90.5
+    assert asyncio.run(store.timeseries(RANGE, "ai_lines"))[0]["value"] == 7
+
+    collectors = asyncio.run(store.collector_status(RANGE))
+    assert {item["box"] for item in collectors} == {"atlas", "compiler"}
+    assert all(item["collector"] == "otel" for item in collectors)
+    with closing(sqlite3.connect(store.path)) as connection:
+        stored = " ".join(
+            value or ""
+            for row in connection.execute(
+                "SELECT attributes_json, payload_json FROM metric_series "
+                "JOIN metric_points ON metric_series.id=metric_points.series_id"
+            )
+            for value in row
+        )
+        assert "sensitive" not in stored
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM metric_series "
+                "WHERE metric_name='codex.sqlite.init.duration_ms'"
+            ).fetchone()[0]
+            == 1
+        )
+
+
+def test_git_summary_activity_filters_cursor_and_purge(tmp_path: Path) -> None:
+    store = InsightsStore(tmp_path / "insights.db")
+    asyncio.run(store.initialize())
+    instance = "33333333-3333-4333-8333-333333333333"
+    payload = sanitize_git_payload(
+        {
+            "repositories": [
+                {
+                    "repo_key": "github.com/example/project",
+                    "commits": [
+                        {
+                            "sha": "a" * 40,
+                            "committed_at": "2026-07-14T19:00:00+00:00",
+                            "additions": 12,
+                            "deletions": 2,
+                            "files_changed": 3,
+                            "binary_files": 1,
+                            "is_merge": False,
+                        },
+                        {
+                            "sha": "b" * 40,
+                            "committed_at": "2026-07-14T19:05:00+00:00",
+                            "additions": 4,
+                            "deletions": 8,
+                            "files_changed": 2,
+                            "binary_files": 0,
+                            "is_merge": True,
+                        },
+                    ],
+                    "working_tree": {
+                        "staged_additions": 3,
+                        "staged_deletions": 1,
+                        "staged_files": 1,
+                        "unstaged_additions": 5,
+                        "unstaged_deletions": 2,
+                        "unstaged_files": 2,
+                        "binary_files": 0,
+                    },
+                }
+            ]
+        }
+    )
+    result = ingest(
+        store,
+        instance_id=instance,
+        box="atlas",
+        batch_id="c" * 64,
+        collector="git",
+        kind="git",
+        payload=payload,
+        points=2,
+    )
+    assert result.accepted is True
+
+    summary = asyncio.run(store.summary(RANGE))
+    assert summary["code"]["commits"] == 2
+    assert summary["code"]["additions"] == 16
+    assert summary["code"]["deletions"] == 10
+    assert summary["code"]["working_tree"]["staged_files"] == 1
+    assert asyncio.run(store.timeseries(RANGE, "git_commits"))[0]["value"] == 2
+    assert asyncio.run(store.timeseries(RANGE, "git_churn"))[0]["value"] == 26
+
+    first, cursor = asyncio.run(store.activity(RANGE, cursor=None, limit=1))
+    second, final_cursor = asyncio.run(store.activity(RANGE, cursor=cursor, limit=1))
+    assert first[0]["is_merge"] is True
+    assert second[0]["is_merge"] is False
+    assert final_cursor is None
+    with pytest.raises(ValueError, match="cursor"):
+        asyncio.run(store.activity(RANGE, cursor="invalid", limit=10))
+
+    filtered = QueryFilters(
+        since=RANGE.since,
+        until=RANGE.until,
+        box="other",
+        repo="github.com/other/project",
+    )
+    assert asyncio.run(store.summary(filtered))["code"]["commits"] == 0
+    assert asyncio.run(store.collector_status(filtered)) == []
+
+    assert asyncio.run(store.purge_box("atlas")) == 1
+    assert asyncio.run(store.purge_box("atlas")) == 0
+    assert asyncio.run(store.summary(RANGE))["code"]["commits"] == 0
+
+
+def test_cumulative_monotonic_series_handles_difference_and_reset(tmp_path: Path) -> None:
+    store = InsightsStore(tmp_path / "insights.db")
+    asyncio.run(store.initialize())
+
+    def cumulative(value: int, observed: int, start: int = 1784056003000000000):
+        return {
+            "resourceMetrics": [
+                {
+                    "resource": {
+                        "attributes": [{"key": "service.name", "value": {"stringValue": "custom"}}]
+                    },
+                    "scopeMetrics": [
+                        {
+                            "metrics": [
+                                {
+                                    "name": "custom.counter",
+                                    "sum": {
+                                        "aggregationTemporality": 2,
+                                        "isMonotonic": True,
+                                        "dataPoints": [
+                                            {
+                                                "startTimeUnixNano": str(start),
+                                                "timeUnixNano": str(observed),
+                                                "asInt": value,
+                                            }
+                                        ],
+                                    },
+                                }
+                            ]
+                        }
+                    ],
+                }
+            ]
+        }
+
+    instance = "44444444-4444-4444-8444-444444444444"
+    for index, (value, observed, start) in enumerate(
+        [
+            (10, 1784056003100000000, 1784056003000000000),
+            (15, 1784056003200000000, 1784056003000000000),
+            (3, 1784056003300000000, 1784056003250000000),
+        ]
+    ):
+        ingest(
+            store,
+            instance_id=instance,
+            box="counter",
+            batch_id=str(index + 1) * 64,
+            collector="otel",
+            kind="otlp",
+            payload=cumulative(value, observed, start),
+            points=1,
+        )
+
+    with closing(sqlite3.connect(store.path)) as connection:
+        values = [
+            row[0]
+            for row in connection.execute(
+                "SELECT value FROM metric_points ORDER BY observed_at"
+            ).fetchall()
+        ]
+    assert values == [10, 5, 3]
+
+
+def test_maintenance_materializes_rollups_and_enforces_retention(tmp_path: Path) -> None:
+    store = InsightsStore(tmp_path / "insights.db", raw_days=30, hourly_days=90, daily_days=365)
+    asyncio.run(store.initialize())
+    codex, points = provider_fixture("codex-0.144.0-otlp.json")
+    ingest(
+        store,
+        instance_id="55555555-5555-4555-8555-555555555555",
+        box="atlas",
+        batch_id="d" * 64,
+        collector="otel",
+        kind="otlp",
+        payload=codex,
+        points=points,
+    )
+
+    result = asyncio.run(store.maintain())
+    assert result["raw_points"] == 0
+    with closing(sqlite3.connect(store.path)) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM metric_rollups_hourly").fetchone()[0] > 0
+        assert connection.execute("SELECT COUNT(*) FROM metric_rollups_daily").fetchone()[0] > 0
+        old = (datetime.now(UTC) - timedelta(days=400)).isoformat()
+        connection.execute("UPDATE metric_points SET observed_at = ?", (old,))
+        connection.commit()
+    deleted = asyncio.run(store.maintain())
+    assert deleted["raw_points"] == points
+
+
+def test_long_range_queries_use_hourly_and_daily_rollups_after_raw_cleanup(
+    tmp_path: Path,
+) -> None:
+    store = InsightsStore(tmp_path / "insights.db", raw_days=30, hourly_days=90, daily_days=365)
+    asyncio.run(store.initialize())
+
+    for index, age_days in enumerate((40, 120)):
+        codex, points = provider_fixture("codex-0.144.0-otlp.json")
+        observed = datetime.now(UTC) - timedelta(days=age_days)
+        nanoseconds = str(int(observed.timestamp() * 1_000_000_000))
+        for resource in codex["resourceMetrics"]:
+            for scope in resource["scopeMetrics"]:
+                for metric in scope["metrics"]:
+                    for form in ("gauge", "sum", "histogram", "exponentialHistogram", "summary"):
+                        for point in metric.get(form, {}).get("dataPoints", []):
+                            point["timeUnixNano"] = nanoseconds
+                            point.pop("startTimeUnixNano", None)
+        ingest(
+            store,
+            instance_id=f"77777777-7777-4777-8777-77777777777{index}",
+            box=f"archive-{index}",
+            batch_id=str(index + 7) * 64,
+            collector="otel",
+            kind="otlp",
+            payload=codex,
+            points=points,
+        )
+
+    asyncio.run(store.maintain())
+    filters = QueryFilters(
+        since=datetime.now(UTC) - timedelta(days=180),
+        until=datetime.now(UTC),
+        group_by="box",
+        bucket="day",
+    )
+    summary = asyncio.run(store.summary(filters))
+    series = asyncio.run(store.timeseries(filters, "tokens"))
+
+    assert summary["ai"]["totals"]["tokens"] == 84
+    assert {item["key"] for item in summary["groups"]} == {"archive-0", "archive-1"}
+    assert sum(item["value"] for item in series) == 84
+    with closing(sqlite3.connect(store.path)) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM metric_points").fetchone()[0] == 0
+        assert connection.execute("SELECT COUNT(*) FROM metric_rollups_hourly").fetchone()[0] > 0
+        assert connection.execute("SELECT COUNT(*) FROM metric_rollups_daily").fetchone()[0] > 0
+
+
+def test_store_rolls_back_invalid_batch_kinds_and_timestamps(tmp_path: Path) -> None:
+    store = InsightsStore(tmp_path / "insights.db")
+    asyncio.run(store.initialize())
+    with pytest.raises(ValueError, match="unsupported"):
+        ingest(
+            store,
+            instance_id="66666666-6666-4666-8666-666666666666",
+            box="atlas",
+            batch_id="e" * 64,
+            collector="agent",
+            kind="other",
+            payload={},
+            points=0,
+        )
+    assert asyncio.run(store.summary(RANGE))["ai"]["totals"]["sessions"] == 0
+
+    future, points = provider_fixture("codex-0.144.0-otlp.json")
+    point = future["resourceMetrics"][0]["scopeMetrics"][0]["metrics"][0]["sum"]["dataPoints"][0]
+    point["timeUnixNano"] = "9999999999999999999"
+    with pytest.raises(ValueError, match="timestamp"):
+        ingest(
+            store,
+            instance_id="66666666-6666-4666-8666-666666666666",
+            box="atlas",
+            batch_id="f" * 64,
+            collector="otel",
+            kind="otlp",
+            payload=future,
+            points=points,
+        )
+
+
+def test_uninitialized_store_is_not_ready(tmp_path: Path) -> None:
+    store = InsightsStore(tmp_path / "missing" / "insights.db")
+    assert asyncio.run(store.ready()) is False

--- a/controller/tests/test_manager.py
+++ b/controller/tests/test_manager.py
@@ -19,6 +19,8 @@ from devboxes_controller.models import CreateDevboxRequest, DevboxState, Preset
 from devboxes_controller.resources import (
     ANNOTATION_CREATED_AT,
     ANNOTATION_EXPIRES_AT,
+    ANNOTATION_INSIGHTS_STATE,
+    ANNOTATION_INSTANCE_ID,
     ANNOTATION_PRESET,
     ANNOTATION_STORAGE,
     ANNOTATION_TTL_HOURS,
@@ -295,6 +297,121 @@ def test_create_uses_portable_node_port_and_default_storage_configuration() -> N
     assert service["spec"]["type"] == "NodePort"
     assert service["metadata"]["annotations"] == {"example.test/private": "true"}
     assert "nodePort" not in service["spec"]["ports"][0]
+
+
+def _legacy_deployment(replicas: int) -> SimpleNamespace:
+    now = datetime.now(UTC)
+    return SimpleNamespace(
+        metadata=SimpleNamespace(
+            name="devbox-atlas",
+            labels={LABEL_NAME: "atlas"},
+            annotations={
+                ANNOTATION_CREATED_AT: now.isoformat(),
+                ANNOTATION_EXPIRES_AT: (now + timedelta(hours=24)).isoformat(),
+                ANNOTATION_PRESET: "small",
+                ANNOTATION_STORAGE: "20Gi",
+                ANNOTATION_TTL_HOURS: "24",
+            },
+        ),
+        spec=SimpleNamespace(
+            replicas=replicas,
+            template=SimpleNamespace(
+                metadata=SimpleNamespace(annotations={}),
+                spec=SimpleNamespace(containers=[SimpleNamespace(name="devbox")]),
+            ),
+        ),
+    )
+
+
+def test_insights_create_scopes_identity_to_the_retained_home_volume() -> None:
+    apps = Mock()
+    apps.read_namespaced_deployment.side_effect = ApiException(status=404)
+    core = Mock()
+    core.read_namespaced_persistent_volume_claim.side_effect = ApiException(status=404)
+    core.read_namespaced_secret.side_effect = ApiException(status=404)
+    manager = DevboxManager(
+        Settings(
+            access_token="test-access-token-at-least-32-characters",
+            insights_enabled=True,
+        ),
+        apps_api=apps,
+        core_api=core,
+    )
+    manager.get = AsyncMock(return_value=Mock())  # type: ignore[method-assign]
+
+    asyncio.run(manager.create(CreateDevboxRequest(name="atlas")))
+
+    pvc = core.create_namespaced_persistent_volume_claim.call_args.args[1]
+    deployment = apps.create_namespaced_deployment.call_args.args[1]
+    instance_id = pvc["metadata"]["annotations"][ANNOTATION_INSTANCE_ID]
+    assert deployment["metadata"]["annotations"][ANNOTATION_INSTANCE_ID] == instance_id
+    sidecar = deployment["spec"]["template"]["spec"]["containers"][1]
+    credential_environment = next(
+        item for item in sidecar["env"] if item["name"] == "DEVBOXES_INSIGHTS_CREDENTIAL"
+    )
+    assert credential_environment["valueFrom"]["secretKeyRef"] == {
+        "name": "devbox-atlas-insights",
+        "key": "credential",
+    }
+    secret = core.create_namespaced_secret.call_args.args[1]
+    credential = secret["stringData"]["credential"]
+    assert credential.startswith(f"v1.{instance_id}.atlas.")
+    assert "test-access-token" not in credential
+
+
+def test_active_legacy_workspace_is_marked_restart_required_without_template_patch() -> None:
+    deployment = _legacy_deployment(1)
+    apps = Mock()
+    apps.list_namespaced_deployment.return_value = SimpleNamespace(items=[deployment])
+    core = Mock()
+    core.read_namespaced_persistent_volume_claim.return_value = SimpleNamespace(
+        metadata=SimpleNamespace(annotations={})
+    )
+    manager = DevboxManager(
+        Settings(
+            access_token="test-access-token-at-least-32-characters",
+            insights_enabled=True,
+        ),
+        apps_api=apps,
+        core_api=core,
+    )
+
+    assert asyncio.run(manager.reconcile_insights()) == ["atlas"]
+
+    patch = apps.patch_namespaced_deployment.call_args.args[2]
+    assert "spec" not in patch
+    assert patch["metadata"]["annotations"][ANNOTATION_INSIGHTS_STATE] == "restart_required"
+    assert ANNOTATION_INSTANCE_ID in patch["metadata"]["annotations"]
+    core.patch_namespaced_persistent_volume_claim.assert_called_once()
+
+
+def test_stopped_legacy_workspace_template_is_reconciled_without_starting_it() -> None:
+    deployment = _legacy_deployment(0)
+    apps = Mock()
+    apps.list_namespaced_deployment.return_value = SimpleNamespace(items=[deployment])
+    apps.read_namespaced_deployment.return_value = _legacy_deployment(0)
+    core = Mock()
+    core.read_namespaced_persistent_volume_claim.return_value = SimpleNamespace(
+        metadata=SimpleNamespace(
+            annotations={ANNOTATION_INSTANCE_ID: "99999999-9999-4999-8999-999999999999"}
+        )
+    )
+    manager = DevboxManager(
+        Settings(
+            access_token="test-access-token-at-least-32-characters",
+            insights_enabled=True,
+        ),
+        apps_api=apps,
+        core_api=core,
+    )
+
+    assert asyncio.run(manager.reconcile_insights()) == ["atlas"]
+
+    patch = apps.patch_namespaced_deployment.call_args.args[2]
+    assert "replicas" not in patch["spec"]
+    containers = patch["spec"]["template"]["spec"]["containers"]
+    assert [item["name"] for item in containers] == ["devbox", "insights-agent"]
+    assert patch["metadata"]["annotations"][ANNOTATION_INSIGHTS_STATE] == "collecting"
 
 
 def test_node_port_model_includes_allocated_port_in_ssh_command() -> None:

--- a/controller/tests/test_resources.py
+++ b/controller/tests/test_resources.py
@@ -1,7 +1,10 @@
 from datetime import UTC, datetime
 
+import pytest
+
 from devboxes_controller.models import CreateDevboxRequest, Preset
 from devboxes_controller.resources import (
+    ANNOTATION_INSTANCE_ID,
     ANNOTATION_TTL_HOURS,
     build_deployment,
     build_pvc,
@@ -79,3 +82,61 @@ def test_service_supports_node_port_and_provider_annotations() -> None:
     assert service["spec"]["type"] == "NodePort"
     assert service["spec"]["externalTrafficPolicy"] == "Local"
     assert service["spec"]["ports"][0]["nodePort"] == 30222
+
+
+def test_insights_sidecar_is_opt_in_scoped_and_hardened() -> None:
+    instance_id = "99999999-9999-4999-8999-999999999999"
+    credential = f"v1.{instance_id}.atlas.{'a' * 43}"
+    deployment = build_deployment(
+        request(),
+        "devboxes",
+        "ghcr.io/vicotrbb/devboxes-workspace:test",
+        "devboxes-workspace",
+        "devboxes-workspace",
+        instance_id=instance_id,
+        insights_enabled=True,
+        insights_endpoint="http://devboxes:8000",
+        insights_credential=credential,
+        insights_scan_interval_seconds=45,
+        insights_repository_depth=3,
+        insights_max_queue_bytes=1048576,
+    )
+    pod = deployment["spec"]["template"]["spec"]
+    main = pod["containers"][0]
+    sidecar = pod["containers"][1]
+    main_environment = {item["name"]: item.get("value") for item in main["env"]}
+    sidecar_environment = {item["name"]: item.get("value") for item in sidecar["env"]}
+
+    assert deployment["metadata"]["annotations"][ANNOTATION_INSTANCE_ID] == instance_id
+    assert main_environment["DEVBOXES_INSIGHTS_ENABLED"] == "true"
+    assert main_environment["OTEL_LOGS_EXPORTER"] == "none"
+    assert main_environment["OTEL_TRACES_EXPORTER"] == "none"
+    assert main_environment["OTEL_METRICS_INCLUDE_SESSION_ID"] == "false"
+    assert main_environment["OTEL_METRICS_INCLUDE_ACCOUNT_UUID"] == "false"
+    assert main_environment["OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"] == "http/json"
+    assert sidecar["image"] == main["image"]
+    assert sidecar["command"] == ["python3", "/usr/local/bin/devbox-insights-agent"]
+    assert sidecar_environment["DEVBOXES_INSIGHTS_CREDENTIAL"] == credential
+    assert sidecar_environment["DEVBOXES_INSIGHTS_ENDPOINT"] == "http://devboxes:8000"
+    assert sidecar["securityContext"] == {
+        "runAsNonRoot": True,
+        "runAsUser": 1000,
+        "runAsGroup": 1000,
+        "allowPrivilegeEscalation": False,
+        "readOnlyRootFilesystem": True,
+        "capabilities": {"drop": ["ALL"]},
+    }
+    assert sidecar["volumeMounts"] == [{"name": "home", "mountPath": "/home/dev"}]
+    assert all(item["name"] != "DEVBOXES_INSIGHTS_CREDENTIAL" for item in main["env"])
+
+
+def test_enabled_insights_requires_a_complete_scoped_configuration() -> None:
+    with pytest.raises(ValueError, match="requires instance"):
+        build_deployment(
+            request(),
+            "devboxes",
+            "workspace:test",
+            "devboxes-workspace",
+            "devboxes-workspace",
+            insights_enabled=True,
+        )

--- a/controller/tests/test_workspace_insights_agent.py
+++ b/controller/tests/test_workspace_insights_agent.py
@@ -1,0 +1,264 @@
+import http.client
+import importlib.util
+import json
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+FIXTURES = Path(__file__).parent / "fixtures"
+AGENT_PATH = Path(__file__).parents[2] / "workspace" / "insights_agent.py"
+
+
+def load_agent() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("devboxes_workspace_insights_agent", AGENT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+agent = load_agent()
+
+
+def test_workspace_sanitizer_matches_pinned_provider_fixtures() -> None:
+    for name, expected in [
+        ("codex-0.144.0-otlp.json", 3),
+        ("claude-2.1.205-otlp.json", 7),
+    ]:
+        payload = json.loads((FIXTURES / name).read_text())
+        sanitized, count = agent.sanitize_otlp(payload, maximum_points=100)
+        serialized = json.dumps(sanitized)
+        assert count == expected
+        assert "sensitive" not in serialized
+        assert "user.id" not in serialized
+        assert "prompt" not in serialized
+
+
+def test_receiver_binds_locally_and_acknowledges_only_committed_metrics(tmp_path: Path) -> None:
+    outbox = agent.Outbox(tmp_path / "outbox.db", 1_000_000)
+    agent.MetricsHandler.outbox = outbox
+    server = agent.ThreadingHTTPServer(("127.0.0.1", 0), agent.MetricsHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        connection = http.client.HTTPConnection("127.0.0.1", server.server_port, timeout=5)
+        body = (FIXTURES / "codex-0.144.0-otlp.json").read_bytes()
+        connection.request(
+            "POST",
+            "/v1/metrics",
+            body=body,
+            headers={"Content-Type": "application/json", "Content-Length": str(len(body))},
+        )
+        response = connection.getresponse()
+        assert response.status == 200
+        assert response.read() == b"{}"
+        assert outbox.due()["kind"] == "otlp"
+
+        connection.request(
+            "POST",
+            "/v1/logs",
+            body=b"{}",
+            headers={"Content-Type": "application/json", "Content-Length": "2"},
+        )
+        assert connection.getresponse().status == 404
+        connection.close()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_main_retries_after_a_transient_initialization_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = 0
+    delays: list[int] = []
+
+    def run() -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise PermissionError("synthetic startup race")
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(agent, "run_agent", run)
+    monkeypatch.setattr(agent.time, "sleep", delays.append)
+
+    with pytest.raises(KeyboardInterrupt):
+        agent.main()
+
+    assert attempts == 2
+    assert delays == [agent.RESTART_DELAY_SECONDS]
+
+
+def test_sender_rejects_non_http_or_credential_bearing_endpoints(tmp_path: Path) -> None:
+    outbox = agent.Outbox(tmp_path / "outbox.db", 1_000_000)
+    with pytest.raises(ValueError, match="invalid Insights endpoint"):
+        agent.Sender(outbox, "file:///tmp/private", "credential")
+    with pytest.raises(ValueError, match="invalid Insights endpoint"):
+        agent.Sender(outbox, "https://user:secret@example.test", "credential")
+
+
+def test_outbox_is_idempotent_bounded_and_tracks_loss(tmp_path: Path) -> None:
+    outbox = agent.Outbox(tmp_path / "outbox.db", 500)
+    first = outbox.enqueue("heartbeat", {"observed_at": "one"}, 3)
+    assert outbox.enqueue("heartbeat", {"observed_at": "one"}, 3) == first
+    for index in range(10):
+        outbox.enqueue("heartbeat", {"observed_at": f"value-{index}"}, 2)
+    assert outbox.queue_bytes() <= 500
+    assert outbox.dropped_points() > 0
+
+    row = outbox.due()
+    assert row is not None
+    outbox.failed(str(row["id"]), int(row["point_count"]), 1, False)
+    another = outbox.due()
+    if another is not None:
+        outbox.sent(str(another["id"]))
+    outbox.set_metadata("custom", "value")
+    assert outbox.get_metadata("custom") == "value"
+    assert outbox.get_metadata("missing") is None
+
+
+def test_outbox_survives_restart_and_expires_oldest_batches(tmp_path: Path) -> None:
+    database = tmp_path / "outbox.db"
+    first = agent.Outbox(database, 1_000_000, maximum_age_seconds=60)
+    batch_id = first.enqueue("heartbeat", {"observed_at": "first"}, 4)
+    restarted = agent.Outbox(database, 1_000_000, maximum_age_seconds=60)
+    assert restarted.due()["id"] == batch_id
+
+    connection = agent.sqlite3.connect(database)
+    try:
+        connection.execute("UPDATE batches SET created_at = '2020-01-01T00:00:00+00:00'")
+        connection.commit()
+    finally:
+        connection.close()
+    restarted.enqueue("heartbeat", {"observed_at": "new"}, 0)
+    assert restarted.dropped_batches() == 1
+    assert restarted.dropped_points() == 4
+
+
+def run_git(repository: Path, *arguments: str) -> None:
+    subprocess.run(  # noqa: S603 - fixed Git test harness with local temporary input
+        ["git", "-C", str(repository), *arguments],  # noqa: S607 - PATH matches production
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def test_git_collector_baselines_then_emits_aggregate_only_commits(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    repository = root / "project"
+    repository.mkdir(parents=True)
+    run_git(repository, "init", "-b", "main")
+    run_git(repository, "config", "user.name", "Private Name")
+    run_git(repository, "config", "user.email", "private@example.com")
+    run_git(
+        repository,
+        "remote",
+        "add",
+        "origin",
+        "https://token:secret@github.com/Example/Project.git",
+    )
+    tracked = repository / "private-path.txt"
+    tracked.write_text("first\n")
+    run_git(repository, "add", ".")
+    run_git(repository, "commit", "-m", "private first message")
+
+    outbox = agent.Outbox(tmp_path / "outbox.db", 1_000_000)
+    collector = agent.GitCollector(outbox, root, 4)
+    assert collector.scan() == 1
+    baseline = json.loads(outbox.due()["body"])
+    assert baseline["payload"]["repositories"][0]["commits"] == []
+    outbox.sent(baseline["batch_id"])
+
+    tracked.write_text("first\nsecond\n")
+    run_git(repository, "add", ".")
+    run_git(repository, "commit", "-m", "private second message")
+    tracked.write_text("first\nsecond\nthird\n")
+    assert collector.scan() == 1
+    collected = json.loads(outbox.due()["body"])
+    serialized = json.dumps(collected)
+    repo = collected["payload"]["repositories"][0]
+
+    assert repo["repo_key"] == "github.com/example/project"
+    assert len(repo["commits"]) == 1
+    assert repo["commits"][0]["additions"] == 1
+    assert repo["working_tree"]["unstaged_additions"] == 1
+    assert "Private Name" not in serialized
+    assert "private@example.com" not in serialized
+    assert "private second message" not in serialized
+    assert "private-path.txt" not in serialized
+    assert "token:secret" not in serialized
+
+
+def test_git_collector_counts_merges_without_double_counting_merge_churn(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    repository = root / "project"
+    repository.mkdir(parents=True)
+    run_git(repository, "init", "-b", "main")
+    run_git(repository, "config", "user.name", "Private Name")
+    run_git(repository, "config", "user.email", "private@example.com")
+    tracked = repository / "tracked.txt"
+    tracked.write_text("base\n")
+    run_git(repository, "add", ".")
+    run_git(repository, "commit", "-m", "baseline")
+
+    outbox = agent.Outbox(tmp_path / "outbox.db", 1_000_000)
+    collector = agent.GitCollector(outbox, root, 4)
+    collector.scan()
+    outbox.sent(str(outbox.due()["id"]))
+
+    run_git(repository, "switch", "-c", "feature")
+    (repository / "feature.txt").write_text("feature\n")
+    run_git(repository, "add", ".")
+    run_git(repository, "commit", "-m", "feature")
+    run_git(repository, "switch", "main")
+    tracked.write_text("base\nmain\n")
+    run_git(repository, "add", ".")
+    run_git(repository, "commit", "-m", "main")
+    run_git(repository, "merge", "--no-ff", "feature", "-m", "merge")
+
+    collector.scan()
+    payload = json.loads(outbox.due()["body"])["payload"]["repositories"][0]
+    commits = payload["commits"]
+    merge = next(item for item in commits if item["is_merge"])
+    non_merges = [item for item in commits if not item["is_merge"]]
+    assert len(commits) == 3
+    assert merge["additions"] == 0
+    assert merge["deletions"] == 0
+    assert sum(item["additions"] for item in non_merges) == 2
+
+
+@pytest.mark.parametrize(
+    "remote,expected",
+    [
+        ("git@github.com:Owner/Repo.git", "github.com/owner/repo"),
+        ("ssh://git@example.com/Owner/Repo.git", None),
+        ("", None),
+    ],
+)
+def test_remote_normalization(remote: str, expected: str | None) -> None:
+    assert agent._github_remote(remote) == expected
+
+
+def test_non_github_remote_seed_removes_credentials() -> None:
+    first = agent._remote_seed("https://token-one@example.com/Owner/Repo.git")
+    second = agent._remote_seed("https://token-two@example.com/Owner/Repo.git")
+
+    assert first == second == "example.com/Owner/Repo"
+    assert "token" not in str(first)
+
+
+def test_numstat_counts_binary_without_guessing_lines() -> None:
+    assert agent._numstat(["4\t2\tpath", "-\t-\tbinary", "invalid"]) == {
+        "additions": 4,
+        "deletions": 2,
+        "files": 2,
+        "binary": 1,
+    }

--- a/controller/uv.lock
+++ b/controller/uv.lock
@@ -382,7 +382,7 @@ wheels = [
 
 [[package]]
 name = "devboxes-controller"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/docs/api.md
+++ b/docs/api.md
@@ -35,6 +35,12 @@ The shared token controls every devbox in the installation, including permanent 
 | `POST` | `/api/v1/devboxes/{name}/start` | 200 | Start compute and renew TTL |
 | `POST` | `/api/v1/devboxes/{name}/stop` | 200 | Stop compute and retain storage |
 | `DELETE` | `/api/v1/devboxes/{name}` | 200 | Delete compute, optionally purge storage |
+| `GET` | `/api/v1/insights/summary` | 200 | Read filtered AI and Git aggregates |
+| `GET` | `/api/v1/insights/timeseries` | 200 | Read a supported metric in hourly or daily buckets |
+| `GET` | `/api/v1/insights/activity` | 200 | Read cursor-paginated aggregate commit activity |
+| `GET` | `/api/v1/insights/capabilities` | 200 | Read collector freshness, queue state, loss, and metric availability |
+| `GET` | `/api/v1/insights/export` | 200 | Export a filtered JSON or CSV summary, or an online SQLite backup |
+| `DELETE` | `/api/v1/insights` | 200 | Explicitly purge history by box or instance ID |
 
 The list endpoint is not paginated. One installation is intended for a small, trusted operator scope.
 
@@ -116,6 +122,27 @@ curl --fail-with-body \
 ```
 
 The response identifies the name, whether storage was purged, and a human-readable message.
+
+## Insights responses
+
+Insights is disabled by default. Authenticated reads return an envelope with `enabled`, `generated_at`, `effective_range`, `filters`, `coverage`, `capabilities`, `storage`, and nullable `data`. Missing or unsupported provider measurements remain null with a capability reason. A zero means the collector reported or derived zero within the selected range.
+
+Read endpoints accept `since`, `until`, `box` or `devbox`, `instance_id`, `provider`, `model`, and `repo` or `repository` where applicable. Summary and capabilities accept `group_by=provider|model|box|repository`. Timeseries requires a supported `metric` and accepts `bucket=hour|day`. Activity accepts an opaque `cursor` and a `limit` from 1 to 200.
+
+Export accepts `format=json|csv|sqlite`. JSON and CSV honor the filters. SQLite returns a consistent online backup of the complete database and intentionally ignores summary filters. Never copy only the live database file while write-ahead logging is active.
+
+Purge requires exactly one selector:
+
+```bash
+curl --fail-with-body \
+  --request DELETE \
+  --header "Authorization: Bearer $DEVBOX_TOKEN" \
+  'https://devboxes.example.com/api/v1/insights?box=atlas'
+```
+
+The hidden workspace ingest endpoint is not a public operator API. It accepts only the per-instance scoped credential, OTLP HTTP JSON metrics inside the bounded Devboxes batch envelope, and optional gzip compression. Browser and CLI bearer tokens are rejected there.
+
+See [Insights](insights.md) for exact metric semantics, privacy constraints, retention, identity, rollout, and backup procedures.
 
 ## Errors
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,6 +27,7 @@ The controller translates lifecycle operations into native Kubernetes resources 
 - One `Deployment` per devbox for disposable compute.
 - One `Service` per devbox for SSH through `LoadBalancer` or `NodePort`.
 - One `PersistentVolumeClaim` per devbox, mounted at `/home/dev`.
+- When Insights is enabled, one scoped ingest `Secret` per devbox and one central Insights `PersistentVolumeClaim` for the controller.
 
 Resource names are deterministic (`devbox-NAME`), and labels plus annotations carry controller ownership, creation time, expiry, preset, repository, and retained storage size.
 
@@ -37,6 +38,10 @@ Disconnecting SSH leaves the pod and tmux session running. Stopping scales the D
 The SSH host key lives on the persistent volume. Recreating a previously deleted devbox with the same name therefore retains both files and host identity. A purge intentionally creates a new identity.
 
 TTL expiry is equivalent to `stop`: it scales compute to zero and never deletes data. Starting a stopped devbox renews its original TTL from the new start time.
+
+When Insights is enabled, persistence has two additional layers. A bounded SQLite outbox lives on each workspace home PVC, so accepted local metric batches survive workspace and controller outages. The controller stores sanitized, deduplicated points, Git aggregates, collector health, and time rollups in a separate central SQLite PVC. Ordinary workspace deletion and home purge do not remove central history. Insights history has its own explicit purge operation.
+
+A UUID instance identity is stored on both the Deployment and home PVC. Retaining and reusing the PVC preserves that identity. Purging the PVC and recreating the box creates a new identity. This separates a box name from the lifetime of the storage that produced its data.
 
 ## Readiness
 
@@ -49,6 +54,7 @@ The workspace entrypoint refuses to start without `SSH_AUTHORIZED_KEYS`. It prep
 - Controller RBAC is a Role scoped to the release namespace; it cannot manage cluster-wide resources.
 - Workspace service accounts have no RBAC binding and do not mount Kubernetes API tokens.
 - Workspace Secrets are mounted read-only with mode `0440`, scoped to the workspace group, and are not embedded in either image.
+- Each Insights ingest credential is HMAC-signed, write-only, scoped to one box and UUID instance, and stored in a dedicated namespaced Secret. It is never a controller, browser, or CLI credential.
 - The controller runs as a non-root user with a read-only root filesystem and all Linux capabilities dropped.
 - The workspace runs as root during initialization, then exposes only the unprivileged `dev` SSH user. Password login and root login are disabled.
 - The trusted `dev` user has passwordless `sudo`. The pod adds only `AUDIT_WRITE`, `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETGID`, `SETUID`, and `SYS_CHROOT`; `AUDIT_WRITE` lets OpenSSH allocate audited PTYs, while `SYS_ADMIN` and privileged mode are not used.
@@ -75,8 +81,8 @@ A retained PVC is expanded when a larger preset is requested, subject to the Sto
 
 ## Availability
 
-The controller is stateless apart from signed sessions and the short-lived in-memory
-authorization-code store. Restarting it cancels pending CLI approvals but does not affect
-issued tokens or devbox state. The chart defaults to one replica because create operations
-and one-time code consumption are optimized for a single trusted operator. The Kubernetes
-API remains the source of truth.
+With Insights disabled, the controller is stateless apart from signed sessions and the short-lived in-memory authorization-code store. Restarting it cancels pending CLI approvals but does not affect issued tokens or devbox state.
+
+With Insights enabled, the controller also owns a stateful SQLite database. The chart requires one controller replica and uses a `Recreate` strategy so one pod owns the database volume at a time. Kubernetes remains the source of truth for workspace lifecycle, while the Insights database is the source of truth for retained telemetry and aggregate activity.
+
+Insights does not restart active legacy workspaces during an upgrade. They expose `restart_required` until a normal stop and start installs the sidecar and its current scoped credential. Stopped workspaces are reconciled in place, and every start reconciles the template before compute is scaled up.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -177,9 +177,44 @@ devbox delete atlas --purge --yes
 
 Use `--yes` only in automation where permanent data deletion is intended.
 
+### `devbox metrics`
+
+Query opt-in Insights data without opening the dashboard. The default command prints a seven-day summary:
+
+```bash
+devbox metrics
+devbox metrics --since 24h --box atlas --provider claude
+devbox metrics --since 30d --group-by model --json
+```
+
+Filters may appear before or after a metrics subcommand:
+
+| Option | Meaning |
+| --- | --- |
+| `--since RANGE` | Relative `24h`, `7d`, or `30d` range, or an RFC 3339 timestamp; default `7d` |
+| `--until TIME` | Inclusive RFC 3339 range end; default is now |
+| `--box NAME` | Restrict to one devbox name |
+| `--provider codex\|claude\|all` | Restrict AI telemetry by provider |
+| `--model MODEL` | Restrict to one provider-reported model |
+| `--repo REPOSITORY` | Restrict Git aggregates to one normalized repository identifier |
+| `--group-by provider\|model\|box\|repository` | Return one supported grouping dimension |
+
+Use the subcommands for collector health, aggregate Git events, stable exports, and explicit deletion:
+
+```bash
+devbox metrics status --box atlas
+devbox metrics activity --since 7d --limit 50
+devbox metrics export --since 30d --format json > insights.json
+devbox metrics export --since 30d --format csv > insights.csv
+devbox metrics purge --box atlas
+devbox metrics purge --box atlas --yes
+```
+
+JSON preserves nullable measurements and response metadata. CSV prefixes spreadsheet formula characters before writing cells. Purge permanently removes central Insights history for every retained instance of the selected box, but it does not delete workspace storage.
+
 ## Output and scripting
 
-Human-readable results go to stdout. Progress and connection-wait messages go to stderr. Failures return a nonzero exit status. `--json` emits formatted JSON for list, status, create, start, and stop workflows, which can be consumed with `jq`:
+Human-readable results go to stdout. Progress and connection-wait messages go to stderr. Failures return a nonzero exit status. `--json` emits formatted JSON for list, status, create, start, stop, and metrics workflows, which can be consumed with `jq`:
 
 ```bash
 devbox list --json | jq -r '.[] | select(.state == "ready") | .name'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,9 +3,9 @@
 Use a values file for durable installations:
 
 ```bash
-helm show values oci://ghcr.io/vicotrbb/charts/devboxes --version 0.2.1 > values.yaml
+helm show values oci://ghcr.io/vicotrbb/charts/devboxes --version 0.3.0 > values.yaml
 helm upgrade --install devboxes oci://ghcr.io/vicotrbb/charts/devboxes \
-  --version 0.2.1 \
+  --version 0.3.0 \
   --namespace devboxes \
   --create-namespace \
   --values values.yaml
@@ -105,9 +105,33 @@ ingress:
 
 The chart does not create certificates or DNS records. Use cert-manager, your cloud controller, or an existing TLS Secret. Keep the controller on a trusted network unless you have intentionally hardened the surrounding ingress, authentication, and rate limiting for internet exposure.
 
+## Insights
+
+Insights is opt-in and disabled by default. When enabled, the controller uses one replica, a `Recreate` deployment strategy, and a persistent SQLite volume. Each new or normally restarted workspace gets a loopback metrics collector sidecar and a scoped write-only ingest credential.
+
+| Value | Default | Meaning |
+| --- | --- | --- |
+| `insights.enabled` | `false` | Enable central storage, workspace collection, APIs, CLI queries, and the dashboard |
+| `insights.signingKeyKey` | empty | Optional dedicated ingest-signing key in `controller.existingSecret` |
+| `insights.storage.existingClaim` | empty | Reuse an existing controller database PVC |
+| `insights.storage.storageClass` | empty | Empty uses the cluster default StorageClass |
+| `insights.storage.size` | `2Gi` | Requested central database capacity |
+| `insights.storage.warningBytes` | `1717986918` | Database-size warning threshold exposed by the API and dashboard |
+| `insights.storage.accessMode` | `ReadWriteOnce` | Use `ReadWriteOncePod` when supported and operationally preferred |
+| `insights.storage.retainOnDelete` | `true` | Keep the chart-created database PVC when the Helm release is deleted |
+| `insights.retention.rawDays` | `30` | Raw metric-point retention |
+| `insights.retention.hourlyDays` | `90` | Hourly rollup retention |
+| `insights.retention.dailyDays` | `365` | Daily rollup and sparse Git activity retention |
+| `insights.agent.scanIntervalSeconds` | `60` | Workspace Git scan and heartbeat interval |
+| `insights.agent.repositoryDepth` | `4` | Maximum repository discovery depth below `/home/dev/workspace` |
+| `insights.agent.maxQueueBytes` | `134217728` | Per-workspace durable outbox byte limit |
+| `insights.agent.maxQueueAgeSeconds` | `604800` | Per-workspace durable outbox age limit |
+
+The central PVC must support SQLite file locking and write-ahead logging. Do not use NFS or another network filesystem with unreliable locking. See [Insights](insights.md) for data semantics, trust boundaries, rollout behavior, and restore procedures.
+
 ## Observability
 
-`/health` verifies the process, `/ready` verifies Kubernetes API access, and `/metrics` exposes a Prometheus gauge by devbox state. Set `serviceMonitor.enabled=true` only when the Prometheus Operator CRDs already exist. Add `serviceMonitor.labels` if your Prometheus selector requires them.
+`/health` verifies the process. `/ready` verifies Kubernetes API access and, when enabled, the Insights store. `/metrics` exposes low-cardinality controller and Insights operational metrics. Set `serviceMonitor.enabled=true` only when the Prometheus Operator CRDs already exist. Add `serviceMonitor.labels` if your Prometheus selector requires them.
 
 ## Upgrades
 

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -21,6 +21,14 @@ session rotation without adding another Secret. The key is optional and must con
 least 32 strong random characters. Rotating whichever effective signing key is configured
 revokes all issued CLI tokens.
 
+## Insights ingest credentials
+
+When Insights is enabled, the controller creates one namespaced Secret per workspace. It contains a write-only, HMAC-signed credential scoped to that box name and UUID instance. The workspace sidecar can submit sanitized batches but cannot read Insights, control devboxes, or mint another credential.
+
+By default, the ingest signing key is derived from the controller access token with its own versioned domain separation. To rotate it independently, add a strong random key of at least 32 characters to the controller Secret and point `insights.signingKeyKey` at that field. Never put the value in Helm values.
+
+The generated per-workspace Secret is deleted with workspace compute. Its value is referenced through `secretKeyRef`, not embedded in the Deployment. Retaining the home PVC preserves the workspace instance ID and outbox; a normal recreate issues a fresh credential for that same instance.
+
 ## Workspace Secret
 
 Create the minimal Secret with an SSH public key:

--- a/docs/development.md
+++ b/docs/development.md
@@ -73,7 +73,7 @@ The documentation check validates local Markdown targets and rejects em dash and
 | `controller/src/devboxes_controller/` | FastAPI routes, authentication, settings, Kubernetes lifecycle, schemas, and manifests |
 | `controller/tests/` | Unit and API regression tests plus the local UI preview fake |
 | `charts/devboxes/` | Helm defaults, values schema, namespaced RBAC, and Kubernetes templates |
-| `workspace/` | Workspace image, SSH entrypoint, shell setup, tmux, and secret bootstrap |
+| `workspace/` | Workspace image, SSH entrypoint, shell setup, tmux, secret bootstrap, and Insights agent |
 | `scripts/` | Installation, verification, release consistency, documentation, and Kind E2E tooling |
 | `docs/` | Public installation, usage, architecture, operations, troubleshooting, and development documentation |
 
@@ -87,7 +87,9 @@ helm template devboxes charts/devboxes --namespace devboxes
 kind create cluster --name devboxes
 ```
 
-The CI Kind job builds both images, loads them into a clean cluster, creates placeholder Secrets, installs the local chart, waits for rollout, and exercises the authenticated API, SSH, stop, retention, recreation, host identity, and purge lifecycle.
+The CI Kind job builds both images and the CLI, loads the images into a clean cluster, creates placeholder Secrets, and installs the local chart with Insights enabled. It exercises the authenticated API, SSH, scoped ingest Secret, provider-shaped OTLP batches, batch deduplication, Git baseline and activity, durable outbox during controller downtime, central database persistence, retained identity, CLI output and exports, explicit Insights purge, workspace recreation, host identity, and final PVC purge.
+
+Privacy tests use fixtures derived from exact Codex and Claude Code clients pinned in the workspace image. Fixtures must use synthetic values. Never commit a real prompt, response, command, path, repository name, email address, provider credential, account identifier, or session identifier. The agent and controller sanitizers are separate trust boundaries and both require regression coverage.
 
 ## Release contract
 

--- a/docs/golden-path.md
+++ b/docs/golden-path.md
@@ -31,6 +31,13 @@ workspace:
     externalTrafficPolicy: Cluster
     loadBalancerSourceRanges:
       - 192.0.2.0/24
+
+insights:
+  enabled: true
+  storage:
+    storageClass: fast-rwo
+    size: 2Gi
+    retainOnDelete: true
 ```
 
 ```bash
@@ -38,12 +45,12 @@ kubectl create namespace devboxes
 # Create devboxes-auth and devboxes-workspace here, as described below.
 
 helm upgrade --install devboxes oci://ghcr.io/vicotrbb/charts/devboxes \
-  --version 0.2.1 \
+  --version 0.3.0 \
   --namespace devboxes \
   --values values.yaml
 ```
 
-Before the Helm command, create `devboxes-auth` and `devboxes-workspace` through your secret manager or the commands in [credentials](credentials.md). Do not place secret values in the Helm values file. Replace the example source range with the actual trusted client network.
+Before the Helm command, create `devboxes-auth` and `devboxes-workspace` through your secret manager or the commands in [credentials](credentials.md). Do not place secret values in the Helm values file. Replace the example source range with the actual trusted client network. Insights remains optional; when enabled, use a low-latency RWO volume with reliable SQLite locking.
 
 ## 3. Warm the workspace image when startup latency matters
 
@@ -109,6 +116,7 @@ kubectl top pod -n devboxes -l devboxes.bonalab.org/name=atlas
 - Use `devbox stop` instead of deleting a box when you plan to resume with the same environment.
 - Avoid `--purge` unless the home volume is intentionally disposable.
 - Keep one controller replica unless you have tested the operational behavior of multiple writers. Kubernetes remains the source of truth, but the supported default is one trusted operator and one controller replica.
+- When Insights is enabled, keep exactly one controller replica, monitor collector freshness and queue loss, and use the online backup export for its database.
 - Track image, chart, and CLI versions together, then read the changelog before every upgrade.
 
 See the Kubernetes documentation for [resource requests and pod quality of service](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/), [StorageClass binding modes](https://kubernetes.io/docs/concepts/storage/storage-classes/), [container image caching](https://kubernetes.io/docs/concepts/containers/images/), and [Service traffic policies](https://kubernetes.io/docs/concepts/services-networking/service/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ Devboxes turns Kubernetes capacity into persistent, SSH-accessible development e
 
 - [CLI reference](cli.md), commands, global flags, environment variables, output, and SSH forwarding.
 - [API reference](api.md), authentication, endpoints, request and response contracts, and errors.
+- [Insights](insights.md), opt-in AI telemetry, aggregate Git activity, privacy boundaries, retention, backup, and purge.
 - The authenticated `/docs` page in a running controller, an operator-focused guide rendered with installation-specific values.
 
 ## Operate Devboxes

--- a/docs/insights.md
+++ b/docs/insights.md
@@ -1,0 +1,126 @@
+# Insights
+
+Insights is an opt-in, single-operator view of locally emitted AI metrics and aggregate Git activity. It is available at `/insights`, through `/api/v1/insights/*`, and through `devbox metrics`. It does not reuse the Prometheus `/metrics` route.
+
+## Enable Insights
+
+Insights is disabled by default. Enable it during install or upgrade:
+
+```yaml
+insights:
+  enabled: true
+  signingKeyKey: ""
+  storage:
+    existingClaim: ""
+    storageClass: ""
+    size: 2Gi
+    warningBytes: 1717986918
+    accessMode: ReadWriteOnce
+    retainOnDelete: true
+  retention:
+    rawDays: 30
+    hourlyDays: 90
+    dailyDays: 365
+  agent:
+    scanIntervalSeconds: 60
+    repositoryDepth: 4
+    maxQueueBytes: 134217728
+    maxQueueAgeSeconds: 604800
+```
+
+The controller must use one replica while Insights is enabled. The chart enforces this and changes the controller Deployment strategy to `Recreate`. The Insights database needs a block or local filesystem that supports SQLite write-ahead logging. Do not place it on NFS or another network filesystem with unreliable shared locking. `ReadWriteOncePod` is available when the cluster and storage driver support it.
+
+## Data path
+
+Each enabled workspace gets an `insights-agent` sidecar from the same workspace image. Codex and Claude Code send metrics to `127.0.0.1:4318` inside the pod network namespace. The agent accepts only OTLP HTTP JSON metrics at `/v1/metrics`, sanitizes them, and commits them to a bounded SQLite outbox on `/home/dev` before acknowledging the client.
+
+The sidecar forwards gzip-compressed batches to the hidden controller ingest route with a write-only HMAC credential scoped to one UUID workspace instance. The credential is stored in a namespaced Kubernetes Secret and never uses the controller or CLI bearer token. The controller sanitizes the batch again, derives the authoritative instance from the credential, deduplicates the batch and point fingerprints, and commits it to the central SQLite database.
+
+Agent failure is fail-open for SSH. The main workspace readiness probe checks only SSH, so an unavailable collector cannot make the development environment unreachable.
+
+## Metric meanings
+
+| Measurement | Codex 0.144.0 | Claude Code 2.1.205 | Meaning |
+| --- | --- | --- | --- |
+| Sessions | Approximate | Reported | Codex counts local process starts. Claude reports its session counter. |
+| Tokens | Reported | Reported | Input, output, cache, and total categories emitted by the local client. |
+| Cost | Not reported | Provider-reported estimate | Claude local telemetry is an estimate and is not a billing record. Devboxes never estimates Codex cost. |
+| Active time | Not reported | Reported | Claude active-time categories only. It is not employee time tracking. |
+| AI-modified lines | Not reported | Reported | Claude edit telemetry only. It is separate from Git churn. |
+| Git commits | Collected independently | Collected independently | All newly observed reachable commits, regardless of AI usage. |
+| Git churn | Collected independently | Collected independently | Committed text additions and deletions from Git numstat. |
+| Working tree | Collected independently | Collected independently | Latest staged and unstaged tracked changes. |
+
+All safe metric names and supported OTLP point forms are retained, including unknown future metrics. The dashboard exposes the currently defined summaries and capability reasons. Unsupported and absent measurements remain `null` with a reason instead of becoming zero.
+
+Insights never computes a productivity score or an AI-written percentage. Claude line counts are not added to Git churn, and AI-attributed commits are not added to a separate commit total.
+
+## Git collection
+
+The agent polls `/home/dev/workspace` every 60 seconds by default and discovers repositories or linked worktrees to the configured depth. The first scan stores ref tips as a baseline and imports no cloned history. Later scans find commits newly reachable from current refs and deduplicate each repository and SHA.
+
+Merge commits count once, with zero additional churn so merged branch changes are not counted twice. Binary files increment the binary and file counts but have no invented line count. The working-tree snapshot separates staged and unstaged tracked changes.
+
+Polling can miss commits that are created and rewritten or deleted entirely between scans. A rebase can make replacement commits newly reachable and therefore observable. The collector does not install hooks, modify `core.hooksPath`, or store author data, messages, paths, patches, file content, commands, or credential-bearing remotes.
+
+GitHub remotes become a credential-free `github.com/owner/repository` key. Other remotes and local-only repositories use a stable non-sensitive hash.
+
+## Privacy and trust boundary
+
+Both agent and controller use an attribute allowlist for provider, model, auth mode, session source, app version, token type, tool category, success, status, start type, edit decision, and active-time category. Resource attributes are limited to service name and version.
+
+The pipeline drops email addresses, user, account, and organization identifiers, session IDs, prompts, responses, lengths, commands, paths, file names, URLs, tool inputs and outputs, error bodies, raw API bodies, logs, traces, and arbitrary attributes.
+
+Devboxes remains a single-operator system without secure per-user attribution or tenant isolation. Metrics are self-reported by software running in a workspace controlled by the devbox user, so that user can disable, alter, or fabricate them. Use Insights for personal operational visibility, not compliance, billing, performance evaluation, or adversarial auditing.
+
+## Identity, rollout, and key rotation
+
+The controller stores a UUID instance ID on both the workspace Deployment and home PVC. Deleting a workspace while retaining its PVC preserves the instance ID. Purging the PVC and recreating the workspace creates a new ID.
+
+An upgrade does not restart active legacy workspaces. They report `restart_required` until a normal stop and start installs the sidecar. Stopped templates are reconciled immediately, and every start reconciles a stale template before scaling it up.
+
+Set `insights.signingKeyKey` to a key in `controller.existingSecret` to use a dedicated ingest signing key. Without it, the controller derives a domain-separated key from the access token. Rotating either effective key invalidates existing ingest credentials. Active workspaces become restart-required, while stopped workspaces receive the new credential immediately.
+
+## Storage, retention, and loss
+
+The workspace outbox defaults to 128 MiB and seven days. It retries with exponential backoff and jitter. When its byte or age bound forces deletion, it removes the oldest batch and reports persistent dropped-batch and dropped-point counters. Collector status then becomes `data_loss_detected`, and coverage is partial.
+
+The central database uses SQLite WAL, `synchronous=FULL`, foreign keys, a five-second busy timeout, serialized writes, and short-lived read connections. Raw metric points default to 30 days, hourly rollups to 90 days, and daily rollups plus sparse Git events to 365 days. The dashboard and API expose database bytes and a configurable warning threshold.
+
+## Backup and restore
+
+Request a consistent SQLite snapshot through the authenticated online-backup export:
+
+```bash
+curl -fsS \
+  -H "Authorization: Bearer $DEVBOX_TOKEN" \
+  -o devboxes-insights.db \
+  "$DEVBOX_URL/api/v1/insights/export?format=sqlite"
+```
+
+This uses the [SQLite online backup API](https://www.sqlite.org/backup.html). Never copy only a live `.db` file while WAL mode is active.
+
+To restore, disable or scale down the controller, replace the database on the Insights PVC with a verified snapshot using an administrative pod, preserve ownership for controller uid and gid 10001, and start the controller. Check `/ready`, the Insights page, and `devbox metrics status` before removing the previous snapshot.
+
+## Disable or purge
+
+Setting `insights.enabled=false` stops central collection and removes the controller data mount from the Deployment. Retained controller and workspace PVC data is not deleted automatically.
+
+Ordinary `devbox delete`, including `--purge`, retains central Insights history. Delete history explicitly:
+
+```bash
+devbox metrics purge --box atlas
+```
+
+Use `--yes` only in automation. The equivalent authenticated API is `DELETE /api/v1/insights?box=atlas`, or use `instance_id` to remove one retained instance.
+
+## Protocol references
+
+- [Codex advanced configuration](https://learn.chatgpt.com/docs/config-file/config-advanced)
+- [Codex configuration basics](https://learn.chatgpt.com/docs/config-file/config-basic)
+- [Claude Code monitoring](https://code.claude.com/docs/en/monitoring-usage)
+- [OTLP specification](https://opentelemetry.io/docs/specs/otlp/)
+- [OpenTelemetry metrics data model](https://opentelemetry.io/docs/specs/otel/metrics/data-model/)
+- [SQLite WAL](https://www.sqlite.org/wal.html) and [PRAGMA reference](https://www.sqlite.org/pragma.html)
+- [Kubernetes persistent volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
+- [Git diff formats](https://git-scm.com/docs/diff-format) and [Git hooks](https://git-scm.com/docs/githooks)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -12,11 +12,11 @@ kubectl logs deployment/devboxes -n devboxes --tail=200
 ./scripts/verify-install.sh
 ```
 
-`/health` proves that the HTTP process responds. `/ready` performs a namespaced Deployment list against the Kubernetes API and returns 503 when that dependency is unavailable. Neither endpoint creates resources.
+`/health` proves that the HTTP process responds. `/ready` performs a namespaced Deployment list against the Kubernetes API and, when enabled, verifies the Insights database. It returns 503 when either required dependency is unavailable. Neither endpoint creates resources.
 
 ## Metrics and logs
 
-`/metrics` exposes `devboxes_total{state=...}` for `starting`, `ready`, `stopped`, and `degraded` boxes. Enable the chart ServiceMonitor only when Prometheus Operator CRDs already exist:
+`/metrics` exposes `devboxes_total{state=...}` for `starting`, `ready`, `stopped`, and `degraded` boxes. When Insights is enabled it also exposes low-cardinality ingest outcomes, dropped points by safe provider label, database bytes, store readiness, and last successful rollup. Enable the chart ServiceMonitor only when Prometheus Operator CRDs already exist:
 
 ```yaml
 serviceMonitor:
@@ -28,7 +28,7 @@ serviceMonitor:
 
 Controller logs record configuration loading, automatic TTL stops, and cleanup errors. Kubernetes events remain the primary source for scheduling, volume, image, and Service allocation failures.
 
-Recommended alerts include controller readiness failure, controller crash loops, degraded boxes, workspace restart growth, PVC capacity pressure, and boxes that remain starting beyond the normal image and volume provisioning window.
+Recommended alerts include controller readiness failure, controller crash loops, degraded boxes, workspace restart growth, PVC capacity pressure, boxes that remain starting beyond the normal image and volume provisioning window, stale Insights collectors, reported outbox loss, and an Insights database beyond its configured warning threshold.
 
 ## Capacity planning
 
@@ -52,6 +52,17 @@ Before relying on a backup process:
 
 Devboxes does not create VolumeSnapshots and does not automatically back up or delete PVCs.
 
+When Insights is enabled, create a consistent database snapshot with the authenticated online-backup endpoint:
+
+```bash
+curl -fsS \
+  -H "Authorization: Bearer $DEVBOX_TOKEN" \
+  -o devboxes-insights.db \
+  "$DEVBOX_URL/api/v1/insights/export?format=sqlite"
+```
+
+Do not copy only the live database file while SQLite WAL mode is active. Restore with the controller stopped, replace the database on the Insights PVC using an administrative pod, preserve ownership for uid and gid 10001, then verify `/ready`, `/insights`, and `devbox metrics status`.
+
 ## Upgrades
 
 Read [CHANGELOG.md](../CHANGELOG.md), back up important volumes, and render the new chart before applying it.
@@ -70,6 +81,8 @@ helm upgrade devboxes oci://ghcr.io/vicotrbb/charts/devboxes \
 ```
 
 Then run `scripts/verify-install.sh`, confirm `/ready`, list existing boxes, create a disposable smoke box, connect over SSH, stop it, start it, and delete it with purge.
+
+Enabling Insights does not force-restart an active legacy workspace. `devbox metrics status` reports `restart_required` until the box goes through a normal stop and start. Stopped workspaces are updated without starting compute. Confirm the expected state before and after the rollout.
 
 Prefer a reviewed values file over `--reuse-values`. It makes removed defaults and configuration drift visible.
 
@@ -95,6 +108,8 @@ kubectl rollout status deployment/devboxes -n devboxes
 
 Rotation invalidates browser sessions and saved CLI tokens. Log in again after the rollout. Rotate immediately after suspected disclosure, then review controller access logs available at the ingress or network boundary.
 
+When `insights.signingKeyKey` is empty, the same controller-token rotation also rotates the domain-separated ingest signing key. Active workspaces need a normal stop and start to receive a new scoped credential. With a dedicated Insights signing key, rotate that field independently and follow the same workspace reconciliation procedure.
+
 Rotate workspace provider tokens independently through the workspace Secret. Existing files copied into persistent homes are not overwritten automatically, so revoke compromised provider sessions at the provider and update affected homes explicitly.
 
 ## Uninstall and data retention
@@ -109,6 +124,8 @@ kubectl get deployment,service,pvc -n devboxes \
 ```
 
 Back up required PVCs, delete boxes through the CLI, and use `--purge` only for volumes approved for permanent removal. Verify the namespace contents before deleting the namespace.
+
+If `insights.storage.retainOnDelete=true`, the chart-created central Insights PVC remains after uninstall. Per-workspace outboxes remain on retained home PVCs. Remove either data layer only after a separate backup and retention decision.
 
 ## Disaster recovery
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -31,7 +31,9 @@ Symptoms include `/ready` returning 503, CLI transport failures, or the dashboar
 4. Confirm the configured namespace matches the Helm release namespace.
 5. Review NetworkPolicy or API-server authorization denials.
 
-The controller needs namespaced access to Deployments, Services, Pods, and PVCs. It does not need cluster-wide RBAC.
+The controller needs namespaced access to Deployments, Services, Pods, PVCs, and its generated per-workspace Insights Secrets. It does not need cluster-wide RBAC.
+
+If Insights is enabled, inspect the central PVC and controller logs for SQLite open, migration, or locking errors. The volume must support normal filesystem locking and WAL. Avoid NFS-backed claims with unreliable lock semantics.
 
 ## Authentication fails
 
@@ -159,6 +161,25 @@ devbox ssh atlas
 ```
 
 Starting renews the original TTL. Use a longer TTL for sustained work, up to the controller maximum, or stop explicitly when idle.
+
+## Insights is empty, stale, or partial
+
+Start with the operator view and one workspace:
+
+```bash
+devbox metrics status --box atlas
+kubectl get deployment devbox-atlas -n devboxes \
+  -o jsonpath='{.spec.template.spec.containers[*].name}{"\n"}'
+kubectl logs deployment/devbox-atlas -n devboxes -c insights-agent --tail=100
+```
+
+`restart_required` means an active workspace predates the enabled or current collector template. Stop and start it normally. `partial` means no first batch has arrived or some selected measurements are unavailable. `stale` means the last heartbeat is too old. `data_loss_detected` means the durable outbox exceeded its byte or age bound and dropped oldest data.
+
+The collector is intentionally fail-open for SSH. A sidecar error does not make the main container unready. Check controller reachability from the pod, the generated per-workspace Secret reference, the central PVC, and the queue fields from `devbox metrics status`.
+
+Codex and Claude Code must run inside an Insights-enabled workspace and send metrics to the injected loopback endpoint. Provider telemetry can change between client versions; Devboxes validates the versions shipped in the workspace image. Git history cloned before the first scan is a baseline and is not imported. Only later reachable commits and current tracked working-tree aggregates appear.
+
+If central data is no longer wanted, use `devbox metrics purge --box NAME`. Workspace `delete --purge` removes the home PVC and local outbox but intentionally does not erase central history.
 
 ## Safe support bundle
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "devboxes-repository-tooling",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "devboxes-repository-tooling",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "devDependencies": {
         "@eslint/js": "10.0.1",
         "eslint": "10.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devboxes-repository-tooling",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "description": "JavaScript and documentation quality gates for Devboxes",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@ set -eu
 
 release="${DEVBOXES_RELEASE:-devboxes}"
 namespace="${DEVBOXES_NAMESPACE:-devboxes}"
-version="${DEVBOXES_VERSION:-0.2.1}"
+version="${DEVBOXES_VERSION:-0.3.0}"
 repository="${DEVBOXES_CHART_REPOSITORY:-oci://ghcr.io/vicotrbb/charts/devboxes}"
 chart_source="${DEVBOXES_CHART_SOURCE:-auto}"
 controller_secret="${DEVBOXES_CONTROLLER_SECRET:-devboxes-auth}"

--- a/scripts/kind-e2e.sh
+++ b/scripts/kind-e2e.sh
@@ -47,6 +47,8 @@ cleanup() {
     kubectl --context "kind-$cluster" get all,pvc -n "$namespace" -o wide >&2 || true
     kubectl --context "kind-$cluster" describe pods -n "$namespace" >&2 || true
     kubectl --context "kind-$cluster" logs -n "$namespace" deployment/devboxes --tail=200 >&2 || true
+    kubectl --context "kind-$cluster" logs -n "$namespace" deployment/devbox-smoke \
+      -c insights-agent --tail=200 >&2 || true
     if [[ -f "$temporary_directory/controller-port-forward.log" ]]; then
       cat "$temporary_directory/controller-port-forward.log" >&2
     fi
@@ -100,6 +102,143 @@ wait_for_http() {
 
 api() {
   curl -fsS -H "Authorization: Bearer $token" "$@"
+}
+
+start_controller_port_forward() {
+  if [[ -n "$controller_port_forward" ]]; then
+    kill "$controller_port_forward" >/dev/null 2>&1 || true
+  fi
+  kubectl -n "$namespace" port-forward service/devboxes "$controller_port:8000" \
+    >"$temporary_directory/controller-port-forward.log" 2>&1 &
+  controller_port_forward=$!
+  wait_for_http \
+    "http://127.0.0.1:$controller_port/health" \
+    "$controller_port_forward" \
+    "$temporary_directory/controller-port-forward.log"
+}
+
+write_otlp_fixture() {
+  output="$1"
+  provider="$2"
+  nonce="$3"
+  token_total="$4"
+  python3 - "$output" "$provider" "$nonce" "$token_total" <<'PY'
+import json
+import sys
+import time
+
+output, provider, nonce, token_total = sys.argv[1:]
+observed = str(time.time_ns() + int(nonce))
+tokens = int(token_total)
+
+
+def attribute(key, value):
+    return {"key": key, "value": {"stringValue": value}}
+
+
+def point(value, **attributes):
+    result = {"timeUnixNano": observed, "asInt": value}
+    if attributes:
+        result["attributes"] = [attribute(key, item) for key, item in attributes.items()]
+    return result
+
+
+def sum_metric(name, points, unit="1"):
+    return {
+        "name": name,
+        "unit": unit,
+        "sum": {
+            "aggregationTemporality": 1,
+            "isMonotonic": True,
+            "dataPoints": points,
+        },
+    }
+
+
+if provider == "codex":
+    input_tokens = max(1, tokens * 2 // 3)
+    output_tokens = tokens - input_tokens
+    metrics = [
+        sum_metric("codex.process.start", [point(1, start_type="cli")]),
+        sum_metric(
+            "codex.turn.token_usage",
+            [
+                point(input_tokens, token_type="input", model="e2e-codex"),
+                point(output_tokens, token_type="output", model="e2e-codex"),
+                point(tokens, token_type="total", model="e2e-codex"),
+            ],
+            "tokens",
+        ),
+    ]
+    service = "codex_cli_rs"
+    version = "0.144.0"
+else:
+    metrics = [
+        sum_metric("claude_code.session.count", [point(1)]),
+        sum_metric(
+            "claude_code.token.usage",
+            [
+                point(tokens - 3, type="input", model="e2e-claude"),
+                point(3, type="output", model="e2e-claude"),
+            ],
+            "tokens",
+        ),
+        {
+            "name": "claude_code.cost.usage",
+            "unit": "USD",
+            "sum": {
+                "aggregationTemporality": 1,
+                "isMonotonic": False,
+                "dataPoints": [{"timeUnixNano": observed, "asDouble": 0.02}],
+            },
+        },
+        {
+            "name": "claude_code.active_time.total",
+            "unit": "s",
+            "sum": {
+                "aggregationTemporality": 1,
+                "isMonotonic": False,
+                "dataPoints": [{"timeUnixNano": observed, "asDouble": 60.0}],
+            },
+        },
+        sum_metric("claude_code.lines_of_code.count", [point(4, type="added")], "lines"),
+    ]
+    service = "claude-code"
+    version = "2.1.205"
+
+payload = {
+    "resourceMetrics": [
+        {
+            "resource": {
+                "attributes": [
+                    attribute("service.name", service),
+                    attribute("service.version", version),
+                ]
+            },
+            "scopeMetrics": [{"metrics": metrics}],
+        }
+    ]
+}
+with open(output, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, separators=(",", ":"), sort_keys=True)
+PY
+}
+
+send_otlp_fixture() {
+  fixture="$1"
+  for _ in {1..30}; do
+    if kubectl -n "$namespace" exec -i deployment/devbox-smoke -c devbox -- \
+      curl -fsS \
+        -H 'Content-Type: application/json' \
+        --data-binary @- \
+        http://127.0.0.1:4318/v1/metrics \
+      <"$fixture" >/dev/null; then
+      return
+    fi
+    sleep 1
+  done
+  printf 'error: local Insights receiver did not accept OTLP metrics\n' >&2
+  return 1
 }
 
 cli() {
@@ -166,6 +305,8 @@ if [[ -n "$published_version" ]]; then
   DEVBOXES_CHART_SOURCE=oci \
   DEVBOXES_VERSION="$published_version" \
     scripts/install.sh \
+    --set insights.enabled=true \
+    --set insights.agent.scanIntervalSeconds=15 \
     --set workspace.sshService.type=NodePort \
     --set workspace.sshService.host=dev-node.example.test
   controller_image="$(kubectl -n "$namespace" get deployment devboxes -o jsonpath='{.spec.template.spec.containers[0].image}')"
@@ -184,6 +325,8 @@ else
     --set controller.image.pullPolicy=Never \
     --set workspace.image.repository=devboxes-workspace \
     --set workspace.image.tag=e2e \
+    --set insights.enabled=true \
+    --set insights.agent.scanIntervalSeconds=15 \
     --set workspace.sshService.type=NodePort \
     --set workspace.sshService.host=dev-node.example.test
 fi
@@ -202,13 +345,7 @@ preserved_github_token="$(
 )"
 test "$preserved_github_token" = preserved-runtime-test-value
 
-kubectl -n "$namespace" port-forward service/devboxes "$controller_port:8000" \
-  >"$temporary_directory/controller-port-forward.log" 2>&1 &
-controller_port_forward=$!
-wait_for_http \
-  "http://127.0.0.1:$controller_port/health" \
-  "$controller_port_forward" \
-  "$temporary_directory/controller-port-forward.log"
+start_controller_port_forward
 api "http://127.0.0.1:$controller_port/api/v1/whoami" >/dev/null
 if [[ -n "$released_cli" ]]; then
   cli --json list | jq -e 'type == "array"' >/dev/null
@@ -296,6 +433,134 @@ for _ in {1..30}; do
   sleep 1
 done
 test "$state" = ready
+container_count="$(
+  kubectl -n "$namespace" get deployment devbox-smoke -o json \
+    | jq '.spec.template.spec.containers | length'
+)"
+test "$container_count" = 2
+instance_id="$(
+  kubectl -n "$namespace" get deployment devbox-smoke -o json \
+    | jq -r '.metadata.annotations["insights.devboxes.bonalab.org/instance-id"]'
+)"
+pvc_instance_id="$(
+  kubectl -n "$namespace" get pvc devbox-smoke-home -o json \
+    | jq -r '.metadata.annotations["insights.devboxes.bonalab.org/instance-id"]'
+)"
+test "$instance_id" = "$pvc_instance_id"
+test "$instance_id" != null
+credential_secret="$(
+  kubectl -n "$namespace" get deployment devbox-smoke -o json \
+    | jq -r '.spec.template.spec.containers[]
+      | select(.name == "insights-agent")
+      | .env[]
+      | select(.name == "DEVBOXES_INSIGHTS_CREDENTIAL")
+      | .valueFrom.secretKeyRef.name'
+)"
+test "$credential_secret" = devbox-smoke-insights
+# The command substitution expands inside the workspace container.
+# shellcheck disable=SC2016
+kubectl -n "$namespace" exec deployment/devbox-smoke -c insights-agent -- \
+  sh -lc 'test "$(stat -c "%u:%g %a" /home/dev/.devbox/insights)" = "1000:1000 700"'
+if kubectl -n "$namespace" get deployment devbox-smoke -o yaml | grep -Fq "$token"; then
+  printf 'error: workspace Deployment exposed the controller access token\n' >&2
+  exit 1
+fi
+
+write_otlp_fixture "$temporary_directory/codex-otlp.json" codex 1 15
+write_otlp_fixture "$temporary_directory/claude-otlp.json" claude 2 10
+send_otlp_fixture "$temporary_directory/codex-otlp.json"
+send_otlp_fixture "$temporary_directory/claude-otlp.json"
+insights_summary=""
+for _ in {1..45}; do
+  insights_summary="$(
+    api "http://127.0.0.1:$controller_port/api/v1/insights/summary?since=24h"
+  )"
+  if jq -e '
+    .data.ai.totals.sessions == 2
+    and .data.ai.totals.tokens == 25
+    and .data.ai.totals.provider_reported_cost_usd == 0.02
+    and .data.ai.totals.active_seconds == 60
+    and .data.ai.totals.ai_lines == 4
+  ' <<<"$insights_summary" >/dev/null; then
+    break
+  fi
+  sleep 1
+done
+jq -e '.data.ai.totals.tokens == 25' <<<"$insights_summary" >/dev/null
+
+send_otlp_fixture "$temporary_directory/codex-otlp.json"
+send_otlp_fixture "$temporary_directory/claude-otlp.json"
+sleep 3
+replayed_summary="$(
+  api "http://127.0.0.1:$controller_port/api/v1/insights/summary?since=24h"
+)"
+jq -e '.data.ai.totals.tokens == 25 and .data.ai.totals.sessions == 2' \
+  <<<"$replayed_summary" >/dev/null
+
+# Variables expand in the workspace shell, not in this process.
+# shellcheck disable=SC2016
+kubectl -n "$namespace" exec deployment/devbox-smoke -c devbox -- \
+  runuser -u dev -- env HOME=/home/dev /bin/bash -lc '
+  set -Eeuo pipefail
+  repository="$HOME/workspace/insights-e2e"
+  mkdir -p "$repository"
+  git -C "$repository" init -b main >/dev/null
+  git -C "$repository" config user.name "Sensitive E2E Name"
+  git -C "$repository" config user.email "sensitive-e2e@example.invalid"
+  printf "baseline\n" >"$repository/private-baseline-name.txt"
+  git -C "$repository" add .
+  git -C "$repository" commit -m "sensitive baseline message" >/dev/null
+'
+sleep 18
+# Variables expand in the workspace shell, not in this process.
+# shellcheck disable=SC2016
+kubectl -n "$namespace" exec deployment/devbox-smoke -c devbox -- \
+  runuser -u dev -- env HOME=/home/dev /bin/bash -lc '
+  set -Eeuo pipefail
+  repository="$HOME/workspace/insights-e2e"
+  printf "baseline\nobserved\n" >"$repository/private-baseline-name.txt"
+  git -C "$repository" add .
+  git -C "$repository" commit -m "sensitive observed message" >/dev/null
+  printf "baseline\nobserved\nworking tree\n" >"$repository/private-baseline-name.txt"
+'
+for _ in {1..45}; do
+  insights_summary="$(
+    api "http://127.0.0.1:$controller_port/api/v1/insights/summary?since=24h"
+  )"
+  if jq -e '
+    .data.code.commits == 1
+    and .data.code.additions == 1
+    and .data.code.working_tree.unstaged_files == 1
+  ' <<<"$insights_summary" >/dev/null; then
+    break
+  fi
+  sleep 1
+done
+jq -e '.data.code.commits == 1 and .data.code.working_tree.unstaged_files == 1' \
+  <<<"$insights_summary" >/dev/null
+
+if [[ -n "$released_cli" ]]; then
+  cli --json metrics --since 24h \
+    | jq -e '.data.ai.totals.tokens == 25 and .data.code.commits == 1' >/dev/null
+  cli metrics --since 24h | grep -F 'INSIGHTS' >/dev/null
+  cli metrics export --since 24h --format csv \
+    | grep -F 'category,provider,metric,value' >/dev/null
+fi
+
+api -o "$temporary_directory/insights-backup.db" \
+  "http://127.0.0.1:$controller_port/api/v1/insights/export?format=sqlite"
+for sensitive_value in \
+  'Sensitive E2E Name' \
+  'sensitive-e2e@example.invalid' \
+  'sensitive baseline message' \
+  'sensitive observed message' \
+  'private-baseline-name.txt'; do
+  if grep -aFq "$sensitive_value" "$temporary_directory/insights-backup.db"; then
+    printf 'error: sensitive Git value reached the central Insights backup\n' >&2
+    exit 1
+  fi
+done
+
 node_port="$(kubectl -n "$namespace" get service devbox-smoke-ssh -o jsonpath='{.spec.ports[0].nodePort}')"
 test -n "$node_port"
 first_host_key="$(kubectl -n "$namespace" exec deployment/devbox-smoke -- cat /home/dev/.devbox/ssh/ssh_host_ed25519_key.pub)"
@@ -381,6 +646,65 @@ fi
 kill "$ssh_port_forward" >/dev/null 2>&1 || true
 ssh_port_forward=""
 
+write_otlp_fixture "$temporary_directory/queued-codex-otlp.json" codex 3 2
+kubectl -n "$namespace" scale deployment/devboxes --replicas=0 >/dev/null
+kubectl -n "$namespace" wait --for=delete pod -l app.kubernetes.io/component=controller --timeout=2m
+if [[ -n "$controller_port_forward" ]]; then
+  kill "$controller_port_forward" >/dev/null 2>&1 || true
+  controller_port_forward=""
+fi
+send_otlp_fixture "$temporary_directory/queued-codex-otlp.json"
+kubectl -n "$namespace" scale deployment/devbox-smoke --replicas=0 >/dev/null
+for _ in {1..30}; do
+  replicas="$(kubectl -n "$namespace" get deployment devbox-smoke -o jsonpath='{.status.replicas}')"
+  [[ -z "$replicas" || "$replicas" == 0 ]] && break
+  sleep 1
+done
+kubectl -n "$namespace" scale deployment/devbox-smoke --replicas=1 >/dev/null
+kubectl -n "$namespace" rollout status deployment/devbox-smoke --timeout="$workspace_timeout"
+queued_batches="$(
+  kubectl -n "$namespace" exec deployment/devbox-smoke -c insights-agent -- \
+    python3 -c 'import sqlite3; connection=sqlite3.connect("/home/dev/.devbox/insights/outbox.db"); print(connection.execute("SELECT COUNT(*) FROM batches").fetchone()[0]); connection.close()'
+)"
+test "$queued_batches" -gt 0
+restarted_instance_id="$(
+  kubectl -n "$namespace" get deployment devbox-smoke -o json \
+    | jq -r '.metadata.annotations["insights.devboxes.bonalab.org/instance-id"]'
+)"
+test "$restarted_instance_id" = "$instance_id"
+
+kubectl -n "$namespace" scale deployment/devboxes --replicas=1 >/dev/null
+kubectl -n "$namespace" rollout status deployment/devboxes --timeout=3m
+start_controller_port_forward
+for _ in {1..45}; do
+  insights_summary="$(
+    api "http://127.0.0.1:$controller_port/api/v1/insights/summary?since=24h"
+  )"
+  if jq -e '
+    .data.ai.totals.sessions == 3
+    and .data.ai.totals.tokens == 27
+    and .data.code.commits == 1
+  ' <<<"$insights_summary" >/dev/null; then
+    break
+  fi
+  sleep 1
+done
+jq -e '.data.ai.totals.tokens == 27 and .data.code.commits == 1' \
+  <<<"$insights_summary" >/dev/null
+
+controller_pod="$(
+  kubectl -n "$namespace" get pod -l app.kubernetes.io/component=controller \
+    -o jsonpath='{.items[0].metadata.name}'
+)"
+kubectl -n "$namespace" delete pod "$controller_pod" --wait=true >/dev/null
+kubectl -n "$namespace" rollout status deployment/devboxes --timeout=3m
+start_controller_port_forward
+persisted_summary="$(
+  api "http://127.0.0.1:$controller_port/api/v1/insights/summary?since=24h"
+)"
+jq -e '.data.ai.totals.tokens == 27 and .data.code.commits == 1' \
+  <<<"$persisted_summary" >/dev/null
+
 if [[ -n "$released_cli" ]]; then
   cli --json stop smoke >/dev/null
 else
@@ -401,6 +725,12 @@ fi
 kubectl -n "$namespace" wait --for=delete deployment/devbox-smoke --timeout=2m
 kubectl -n "$namespace" wait --for=delete service/devbox-smoke-ssh --timeout=2m
 kubectl -n "$namespace" get pvc devbox-smoke-home >/dev/null
+kubectl -n "$namespace" wait --for=delete secret/devbox-smoke-insights --timeout=2m
+retained_summary="$(
+  api "http://127.0.0.1:$controller_port/api/v1/insights/summary?since=24h&box=smoke"
+)"
+jq -e '.data.ai.totals.tokens == 27 and .data.code.commits == 1' \
+  <<<"$retained_summary" >/dev/null
 
 if [[ -n "$released_cli" ]]; then
   cli --json create smoke --preset small --ttl 4 --no-wait >/dev/null
@@ -411,10 +741,30 @@ else
     "http://127.0.0.1:$controller_port/api/v1/devboxes" >/dev/null
 fi
 kubectl -n "$namespace" rollout status deployment/devbox-smoke --timeout="$workspace_timeout"
+recreated_instance_id="$(
+  kubectl -n "$namespace" get deployment devbox-smoke -o json \
+    | jq -r '.metadata.annotations["insights.devboxes.bonalab.org/instance-id"]'
+)"
+test "$recreated_instance_id" = "$instance_id"
 second_host_key="$(kubectl -n "$namespace" exec deployment/devbox-smoke -- cat /home/dev/.devbox/ssh/ssh_host_ed25519_key.pub)"
 test "$first_host_key" = "$second_host_key"
 kubectl -n "$namespace" exec deployment/devbox-smoke -- \
   grep -Fx persistent /home/dev/workspace/e2e-persistence >/dev/null
+
+if [[ -n "$released_cli" ]]; then
+  cli metrics purge --box smoke --yes >/dev/null
+else
+  api -X DELETE \
+    "http://127.0.0.1:$controller_port/api/v1/insights?box=smoke" >/dev/null
+fi
+purged_summary="$(
+  api "http://127.0.0.1:$controller_port/api/v1/insights/summary?since=24h&box=smoke"
+)"
+jq -e '
+  .data.ai.totals.tokens == 0
+  and .data.ai.totals.sessions == 0
+  and .data.code.commits == 0
+' <<<"$purged_summary" >/dev/null
 
 if [[ -n "$released_cli" ]]; then
   cli delete smoke --purge --yes >/dev/null
@@ -424,8 +774,8 @@ fi
 kubectl -n "$namespace" wait --for=delete pvc/devbox-smoke-home --timeout=2m
 
 if [[ -n "$published_version" ]]; then
-  printf 'Verified published %s chart, images, and CLI through clean install, API, PVC, NodePort %s, SSH, stop, retain, reuse, host identity, and purge.\n' \
+  printf 'Verified published %s chart, images, and CLI through clean install, Insights ingest, Git aggregation, deduplication, durable outboxes, central restart, API, PVC, NodePort %s, SSH, retain, reuse, and explicit purge.\n' \
     "$published_version" "$node_port"
 else
-  printf 'Verified clean install, API, PVC, NodePort %s, SSH, stop, retain, reuse, host identity, and purge.\n' "$node_port"
+  printf 'Verified clean install, Insights ingest, Git aggregation, deduplication, durable outboxes, central restart, API, PVC, NodePort %s, SSH, retain, reuse, and explicit purge.\n' "$node_port"
 fi

--- a/scripts/test-helm-insights.sh
+++ b/scripts/test-helm-insights.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+project_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+chart="$project_directory/charts/devboxes"
+temporary_directory="$(mktemp -d)"
+trap 'rm -rf "$temporary_directory"' EXIT
+
+helm lint "$chart" --strict
+
+helm template devboxes "$chart" --namespace devboxes \
+  >"$temporary_directory/disabled.yaml"
+grep -Fq 'type: RollingUpdate' "$temporary_directory/disabled.yaml"
+if grep -Fq 'app.kubernetes.io/component: insights' "$temporary_directory/disabled.yaml"; then
+  printf 'error: disabled render unexpectedly created Insights storage\n' >&2
+  exit 1
+fi
+
+helm template devboxes "$chart" --namespace devboxes \
+  --set insights.enabled=true \
+  >"$temporary_directory/enabled.yaml"
+grep -Fq 'kind: PersistentVolumeClaim' "$temporary_directory/enabled.yaml"
+grep -Fq 'app.kubernetes.io/component: insights' "$temporary_directory/enabled.yaml"
+grep -Fq 'type: Recreate' "$temporary_directory/enabled.yaml"
+grep -Fq 'mountPath: /var/lib/devboxes' "$temporary_directory/enabled.yaml"
+grep -Fq 'readOnlyRootFilesystem: true' "$temporary_directory/enabled.yaml"
+grep -Fq 'name: DEVBOXES_INSIGHTS_ENABLED' "$temporary_directory/enabled.yaml"
+
+helm template devboxes "$chart" --namespace devboxes \
+  --set insights.enabled=true \
+  --set insights.storage.existingClaim=existing-insights \
+  >"$temporary_directory/existing.yaml"
+grep -Fq 'claimName: existing-insights' "$temporary_directory/existing.yaml"
+if grep -Fq 'app.kubernetes.io/component: insights' "$temporary_directory/existing.yaml"; then
+  printf 'error: existingClaim render unexpectedly created an Insights PVC\n' >&2
+  exit 1
+fi
+
+for access_mode in ReadWriteOnce ReadWriteOncePod; do
+  helm template devboxes "$chart" --namespace devboxes \
+    --set insights.enabled=true \
+    --set "insights.storage.accessMode=$access_mode" \
+    >"$temporary_directory/$access_mode.yaml"
+  grep -Fq -- "- $access_mode" "$temporary_directory/$access_mode.yaml"
+done
+
+if helm template devboxes "$chart" --namespace devboxes \
+  --set insights.enabled=true \
+  --set controller.replicaCount=2 \
+  >"$temporary_directory/invalid.yaml" 2>"$temporary_directory/invalid.err"; then
+  printf 'error: Insights render accepted multiple controller replicas\n' >&2
+  exit 1
+fi
+grep -Fq 'controller.replicaCount must be exactly 1' "$temporary_directory/invalid.err"
+
+printf 'Verified disabled and enabled Insights Helm contracts.\n'

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -92,11 +92,16 @@ RUN tic -x -o /usr/share/terminfo /usr/local/share/devboxes/ghostty.terminfo \
 
 COPY --chmod=0755 entrypoint.sh /usr/local/bin/devbox-entrypoint
 COPY --chmod=0755 devbox-shell /usr/local/bin/devbox-shell
+COPY --chmod=0555 insights_agent.py /usr/local/bin/devbox-insights-agent
+COPY --chmod=0444 codex-insights.toml /usr/local/share/devboxes/codex-insights.toml
 COPY --chmod=0644 devbox-secrets.sh /etc/profile.d/devbox-secrets.sh
 COPY --chmod=0644 sshd_config /etc/ssh/sshd_config_devbox
 COPY --chmod=0644 bashrc /etc/devbox/skel/.bashrc
 COPY --chmod=0644 zshrc /etc/devbox/skel/.zshrc
 COPY --chmod=0644 tmux.conf /etc/devbox/skel/.tmux.conf
+
+RUN python3 -m py_compile /usr/local/bin/devbox-insights-agent \
+    && rm -rf /usr/local/bin/__pycache__
 
 EXPOSE 2222
 ENTRYPOINT ["/usr/local/bin/devbox-entrypoint"]

--- a/workspace/codex-insights.toml
+++ b/workspace/codex-insights.toml
@@ -1,0 +1,5 @@
+[otel]
+exporter = "none"
+trace_exporter = "none"
+log_user_prompt = false
+metrics_exporter = { otlp-http = { endpoint = "http://127.0.0.1:4318/v1/metrics", protocol = "json" } }

--- a/workspace/entrypoint.sh
+++ b/workspace/entrypoint.sh
@@ -38,6 +38,7 @@ mkdir -p \
   "$HOME_DIR/.ssh" \
   "$HOST_KEY_DIR" \
   "$HOME_DIR/workspace"
+install -o dev -g dev -m 0700 -d "$HOME_DIR/.devbox/insights"
 install -o root -g root -m 0755 -d /run/sshd
 chown dev:dev "$HOME_DIR"
 chown -R dev:dev "$HOME_DIR/.cargo" "$HOME_DIR/.local" "$HOME_DIR/.ssh" "$HOME_DIR/workspace"
@@ -72,6 +73,12 @@ as_dev git config --global credential.https://github.com.helper '!gh auth git-cr
 as_dev git config --global credential.https://gist.github.com.helper '!gh auth git-credential'
 
 install -o dev -g dev -m 0700 -d "$HOME_DIR/.codex" "$HOME_DIR/.claude"
+if [[ "${DEVBOXES_INSIGHTS_ENABLED:-false}" == true ]]; then
+  install -o root -g root -m 0755 -d /etc/codex
+  install -o root -g root -m 0644 \
+    /usr/local/share/devboxes/codex-insights.toml \
+    /etc/codex/config.toml
+fi
 if [[ ! -s "$HOME_DIR/.codex/auth.json" && -s "$SECRETS_DIR/CODEX_AUTH_JSON" ]]; then
   install -o dev -g dev -m 0600 "$SECRETS_DIR/CODEX_AUTH_JSON" "$HOME_DIR/.codex/auth.json"
 elif [[ ! -s "$HOME_DIR/.codex/auth.json" && -s "$SECRETS_DIR/CODEX_ACCESS_TOKEN" ]]; then

--- a/workspace/insights_agent.py
+++ b/workspace/insights_agent.py
@@ -1,0 +1,919 @@
+#!/usr/bin/env python3
+"""Collect privacy-preserving local metrics and Git aggregates for Devboxes Insights."""
+
+# ruff: noqa: D102, D103
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+import math
+import os
+import random
+import re
+import sqlite3
+import subprocess
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from contextlib import suppress
+from datetime import UTC, datetime
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+AGENT_VERSION = "1"
+PROVIDER_VERSIONS = {"codex": "0.144.0", "claude": "2.1.205"}
+OTLP_PATH = "/v1/metrics"
+MAX_OTLP_BYTES = 8_388_608
+RESTART_DELAY_SECONDS = 5
+SAFE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,159}$")
+SAFE_VALUE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,159}$")
+ATTRIBUTE_ALIASES = {
+    "provider": "provider",
+    "model": "model",
+    "gen_ai.request.model": "model",
+    "auth_mode": "auth_mode",
+    "session_source": "session_source",
+    "query_source": "session_source",
+    "app.version": "app.version",
+    "service.version": "app.version",
+    "token_type": "token_type",
+    "type": "type",
+    "tool": "tool",
+    "tool_name": "tool",
+    "success": "success",
+    "status": "status",
+    "start_type": "start_type",
+    "decision": "decision",
+}
+RESOURCE_ATTRIBUTES = {"service.name", "service.version"}
+POINT_SCALARS = {
+    "startTimeUnixNano",
+    "timeUnixNano",
+    "asDouble",
+    "asInt",
+    "count",
+    "sum",
+    "min",
+    "max",
+    "scale",
+    "zeroCount",
+    "zeroThreshold",
+    "flags",
+}
+POINT_ARRAYS = {"bucketCounts", "explicitBounds"}
+
+
+class PayloadError(ValueError):
+    """Represent a safe, content-free collector validation error."""
+
+
+class Outbox:
+    """Persist sanitized batches before acknowledging local producers."""
+
+    def __init__(
+        self,
+        path: Path,
+        maximum_bytes: int,
+        maximum_age_seconds: int = 604_800,
+    ) -> None:
+        self.path = path
+        self.maximum_bytes = maximum_bytes
+        self.maximum_age_seconds = maximum_age_seconds
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.path, timeout=5, isolation_level=None)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA busy_timeout=5000")
+        connection.execute("PRAGMA synchronous=FULL")
+        return connection
+
+    def _initialize(self) -> None:
+        connection = self._connect()
+        try:
+            connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA synchronous=FULL")
+            connection.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS batches (
+                    id TEXT PRIMARY KEY,
+                    kind TEXT NOT NULL,
+                    body TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    point_count INTEGER NOT NULL,
+                    size_bytes INTEGER NOT NULL,
+                    attempts INTEGER NOT NULL DEFAULT 0,
+                    next_attempt REAL NOT NULL DEFAULT 0
+                );
+                CREATE INDEX IF NOT EXISTS idx_outbox_due ON batches(next_attempt, created_at);
+                CREATE TABLE IF NOT EXISTS metadata (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                );
+                """
+            )
+        finally:
+            connection.close()
+
+    def enqueue(self, kind: str, payload: dict[str, Any], point_count: int) -> str:
+        canonical_payload = canonical(payload)
+        batch_id = hashlib.sha256(f"{kind}:".encode() + canonical_payload.encode()).hexdigest()
+        created_at = now_text()
+        body = canonical(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "batch_id": batch_id,
+                "sent_at": created_at,
+                "collector": {"otlp": "otel", "git": "git", "heartbeat": "agent"}[kind],
+                "kind": kind,
+                "payload": payload,
+            }
+        )
+        size = len(body.encode())
+        with self._lock:
+            connection = self._connect()
+            try:
+                connection.execute("BEGIN IMMEDIATE")
+                connection.execute(
+                    """
+                    INSERT OR IGNORE INTO batches(id, kind, body, created_at, point_count,
+                        size_bytes)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (batch_id, kind, body, created_at, point_count, size),
+                )
+                self._enforce_limit(connection)
+                connection.commit()
+            except Exception:
+                connection.rollback()
+                raise
+            finally:
+                connection.close()
+        return batch_id
+
+    def _enforce_limit(self, connection: sqlite3.Connection) -> None:
+        cutoff = datetime.fromtimestamp(time.time() - self.maximum_age_seconds, UTC).isoformat()
+        expired = connection.execute(
+            "SELECT id, size_bytes, point_count FROM batches WHERE created_at < ? "
+            "ORDER BY created_at, id",
+            (cutoff,),
+        ).fetchall()
+        for row in expired:
+            self._drop(connection, row)
+        total = int(
+            connection.execute("SELECT COALESCE(SUM(size_bytes), 0) FROM batches").fetchone()[0]
+        )
+        while total > self.maximum_bytes:
+            row = connection.execute(
+                "SELECT id, size_bytes, point_count FROM batches ORDER BY created_at, id LIMIT 1"
+            ).fetchone()
+            if row is None:
+                break
+            self._drop(connection, row)
+            total -= int(row["size_bytes"])
+
+    @classmethod
+    def _drop(cls, connection: sqlite3.Connection, row: sqlite3.Row) -> None:
+        connection.execute("DELETE FROM batches WHERE id = ?", (row["id"],))
+        cls._increment_metadata(connection, "dropped_batches", 1)
+        cls._increment_metadata(connection, "dropped_points", int(row["point_count"]))
+
+    @staticmethod
+    def _increment_metadata(connection: sqlite3.Connection, key: str, increment: int) -> None:
+        connection.execute(
+            """
+            INSERT INTO metadata(key, value) VALUES (?, ?)
+            ON CONFLICT(key) DO UPDATE SET value=CAST(metadata.value AS INTEGER)+excluded.value
+            """,
+            (key, str(increment)),
+        )
+
+    def due(self) -> sqlite3.Row | None:
+        with self._lock:
+            connection = self._connect()
+            try:
+                return connection.execute(
+                    "SELECT * FROM batches WHERE next_attempt <= ? ORDER BY created_at, id LIMIT 1",
+                    (time.time(),),
+                ).fetchone()
+            finally:
+                connection.close()
+
+    def sent(self, batch_id: str) -> None:
+        with self._lock:
+            connection = self._connect()
+            try:
+                connection.execute("DELETE FROM batches WHERE id = ?", (batch_id,))
+            finally:
+                connection.close()
+
+    def failed(self, batch_id: str, point_count: int, attempts: int, permanent: bool) -> None:
+        with self._lock:
+            connection = self._connect()
+            try:
+                connection.execute("BEGIN IMMEDIATE")
+                if permanent or attempts >= 12:
+                    connection.execute("DELETE FROM batches WHERE id = ?", (batch_id,))
+                    self._increment_metadata(connection, "dropped_batches", 1)
+                    self._increment_metadata(connection, "dropped_points", point_count)
+                else:
+                    delay = min(300.0, 2.0 ** min(attempts, 8)) + random.uniform(  # noqa: S311 - retry jitter is not a security value
+                        0, 1
+                    )
+                    connection.execute(
+                        "UPDATE batches SET attempts=?, next_attempt=? WHERE id=?",
+                        (attempts, time.time() + delay, batch_id),
+                    )
+                connection.commit()
+            except Exception:
+                connection.rollback()
+                raise
+            finally:
+                connection.close()
+
+    def queue_bytes(self) -> int:
+        with self._lock:
+            connection = self._connect()
+            try:
+                return int(
+                    connection.execute(
+                        "SELECT COALESCE(SUM(size_bytes), 0) FROM batches"
+                    ).fetchone()[0]
+                )
+            finally:
+                connection.close()
+
+    def dropped_points(self) -> int:
+        value = self.get_metadata("dropped_points")
+        return int(value) if value and value.isdigit() else 0
+
+    def dropped_batches(self) -> int:
+        value = self.get_metadata("dropped_batches")
+        return int(value) if value and value.isdigit() else 0
+
+    def get_metadata(self, key: str) -> str | None:
+        with self._lock:
+            connection = self._connect()
+            try:
+                row = connection.execute(
+                    "SELECT value FROM metadata WHERE key = ?", (key,)
+                ).fetchone()
+                return str(row["value"]) if row else None
+            finally:
+                connection.close()
+
+    def set_metadata(self, key: str, value: str) -> None:
+        with self._lock:
+            connection = self._connect()
+            try:
+                connection.execute(
+                    """
+                    INSERT INTO metadata(key, value) VALUES (?, ?)
+                    ON CONFLICT(key) DO UPDATE SET value=excluded.value
+                    """,
+                    (key, value),
+                )
+            finally:
+                connection.close()
+
+
+class MetricsHandler(BaseHTTPRequestHandler):
+    """Accept only local metrics OTLP/HTTP JSON and acknowledge after commit."""
+
+    server_version = "devboxes-insights"
+    outbox: Outbox
+
+    def do_POST(self) -> None:
+        if self.path != OTLP_PATH:
+            self._json_error(HTTPStatus.NOT_FOUND)
+            return
+        if self.headers.get_content_type() != "application/json":
+            self._json_error(HTTPStatus.UNSUPPORTED_MEDIA_TYPE)
+            return
+        if self.headers.get("Content-Encoding", "identity").lower() not in {"", "identity"}:
+            self._json_error(HTTPStatus.UNSUPPORTED_MEDIA_TYPE)
+            return
+        try:
+            length = int(self.headers.get("Content-Length", ""))
+        except ValueError:
+            self._json_error(HTTPStatus.LENGTH_REQUIRED)
+            return
+        if length <= 0 or length > MAX_OTLP_BYTES:
+            self._json_error(HTTPStatus.REQUEST_ENTITY_TOO_LARGE)
+            return
+        try:
+            candidate = json.loads(self.rfile.read(length))
+            sanitized, points = sanitize_otlp(candidate, maximum_points=10_000)
+            self.outbox.enqueue("otlp", sanitized, points)
+        except (UnicodeDecodeError, json.JSONDecodeError, PayloadError, sqlite3.Error):
+            self._json_error(HTTPStatus.BAD_REQUEST)
+            return
+        response = b"{}"
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(response)))
+        self.end_headers()
+        self.wfile.write(response)
+
+    def do_GET(self) -> None:
+        self._json_error(HTTPStatus.METHOD_NOT_ALLOWED)
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+    def _json_error(self, status: HTTPStatus) -> None:
+        body = b'{"error":"metrics batch rejected"}'
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+class Sender:
+    """Drain the outbox over authenticated compressed HTTP with bounded retries."""
+
+    def __init__(self, outbox: Outbox, endpoint: str, credential: str) -> None:
+        self.outbox = outbox
+        parsed = urllib.parse.urlsplit(endpoint)
+        if (
+            parsed.scheme not in {"http", "https"}
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ValueError("invalid Insights endpoint")
+        self.endpoint = endpoint.rstrip("/") + "/internal/v1/insights/batches"
+        self.credential = credential
+
+    def run(self, stopped: threading.Event) -> None:
+        while not stopped.wait(0.5):
+            row = self.outbox.due()
+            if row is None:
+                continue
+            body = json.loads(row["body"])
+            dropped_points = self.outbox.dropped_points()
+            last_error = self.outbox.get_metadata("last_error_category") or None
+            body.update(
+                {
+                    "collector_version": AGENT_VERSION,
+                    "provider_versions": PROVIDER_VERSIONS,
+                    "last_successful_send_at": self.outbox.get_metadata("last_successful_send_at"),
+                    "last_error_category": last_error,
+                    "queue_bytes": self.outbox.queue_bytes(),
+                    "dropped_batches": self.outbox.dropped_batches(),
+                    "dropped_points": dropped_points,
+                    "status": "ok" if dropped_points == 0 and last_error is None else "degraded",
+                    "capability_reason": (
+                        "queue loss detected"
+                        if dropped_points
+                        else ("collector degraded" if last_error else None)
+                    ),
+                }
+            )
+            encoded = gzip.compress(canonical(body).encode(), compresslevel=6)
+            request = urllib.request.Request(  # noqa: S310 - scheme validated in constructor
+                self.endpoint,
+                data=encoded,
+                method="POST",
+                headers={
+                    "Authorization": f"Bearer {self.credential}",
+                    "Content-Type": "application/json",
+                    "Content-Encoding": "gzip",
+                    "Accept": "application/json",
+                    "User-Agent": f"devboxes-insights-agent/{AGENT_VERSION}",
+                },
+            )
+            attempts = int(row["attempts"]) + 1
+            try:
+                with urllib.request.urlopen(  # noqa: S310 - request URL was validated
+                    request, timeout=10
+                ) as response:
+                    if 200 <= response.status < 300:
+                        self.outbox.sent(str(row["id"]))
+                        self.outbox.set_metadata("last_successful_send_at", now_text())
+                        self.outbox.set_metadata("last_error_category", "")
+                    else:
+                        self.outbox.set_metadata("last_error_category", "server")
+                        self.outbox.failed(str(row["id"]), int(row["point_count"]), attempts, False)
+            except urllib.error.HTTPError as error:
+                permanent = 400 <= error.code < 500 and error.code != HTTPStatus.TOO_MANY_REQUESTS
+                category = (
+                    "rate_limited"
+                    if error.code == HTTPStatus.TOO_MANY_REQUESTS
+                    else ("rejected" if permanent else "server")
+                )
+                self.outbox.set_metadata("last_error_category", category)
+                self.outbox.failed(str(row["id"]), int(row["point_count"]), attempts, permanent)
+            except (OSError, urllib.error.URLError):
+                self.outbox.set_metadata("last_error_category", "network")
+                self.outbox.failed(str(row["id"]), int(row["point_count"]), attempts, False)
+
+
+class GitCollector:
+    """Observe new reachable commits and aggregate worktree churn without paths."""
+
+    def __init__(self, outbox: Outbox, root: Path, maximum_depth: int) -> None:
+        self.outbox = outbox
+        self.root = root
+        self.maximum_depth = maximum_depth
+
+    def run(self, stopped: threading.Event, interval: int) -> None:
+        while not stopped.is_set():
+            with suppress(OSError, subprocess.SubprocessError, ValueError, sqlite3.Error):
+                self.scan()
+            stopped.wait(interval)
+
+    def scan(self) -> int:
+        repositories = []
+        pending_metadata: list[tuple[str, dict[str, str]]] = []
+        for path in self._discover():
+            scanned = self._scan_repository(path)
+            if scanned is not None:
+                repository, metadata_key, refs = scanned
+                repositories.append(repository)
+                pending_metadata.append((metadata_key, refs))
+        if repositories:
+            commit_count = sum(len(item["commits"]) for item in repositories)
+            self.outbox.enqueue("git", {"repositories": repositories}, commit_count)
+            for metadata_key, refs in pending_metadata:
+                self.outbox.set_metadata(metadata_key, canonical(refs))
+        return len(repositories)
+
+    def _discover(self) -> list[Path]:
+        if not self.root.exists():
+            return []
+        repositories: list[Path] = []
+        root_depth = len(self.root.parts)
+        for current, directories, files in os.walk(self.root):
+            path = Path(current)
+            depth = len(path.parts) - root_depth
+            if ".git" in directories or ".git" in files:
+                repositories.append(path)
+                directories[:] = []
+                continue
+            directories[:] = [
+                item
+                for item in directories
+                if item not in {".git", "node_modules", "target", ".venv"}
+                and depth < self.maximum_depth
+            ]
+        return repositories
+
+    def _scan_repository(self, path: Path) -> tuple[dict[str, Any], str, dict[str, str]] | None:
+        repo_key = self._repo_key(path)
+        refs = self._refs(path)
+        if not refs:
+            return None
+        metadata_key = f"git-refs:{repo_key}"
+        previous_raw = self.outbox.get_metadata(metadata_key)
+        previous = json.loads(previous_raw) if previous_raw else None
+        commits: list[dict[str, Any]] = []
+        if isinstance(previous, dict):
+            commits = self._new_commits(path, refs, previous)
+        worktree = self._worktree(path)
+        return (
+            {"repo_key": repo_key, "commits": commits, "working_tree": worktree},
+            metadata_key,
+            refs,
+        )
+
+    def _repo_key(self, path: Path) -> str:
+        remote = self._git(path, "config", "--get", "remote.origin.url", check=False).strip()
+        github = _github_remote(remote)
+        if github:
+            return github
+        remote_seed = _remote_seed(remote)
+        if remote_seed:
+            return "remote-" + hashlib.sha256(remote_seed.encode()).hexdigest()[:32]
+        root_commit = self._git(path, "rev-list", "--max-parents=0", "HEAD", check=False).strip()
+        seed = root_commit.splitlines()[0] if root_commit else str(path)
+        return "local-" + hashlib.sha256(seed.encode()).hexdigest()[:32]
+
+    def _refs(self, path: Path) -> dict[str, str]:
+        output = self._git(path, "for-each-ref", "--format=%(refname)%00%(objectname)")
+        result: dict[str, str] = {}
+        for line in output.splitlines():
+            parts = line.split("\x00")
+            if len(parts) == 2 and re.fullmatch(r"[0-9a-f]{40,64}", parts[1]):
+                result[parts[0]] = parts[1]
+        head = self._git(path, "rev-parse", "HEAD", check=False).strip()
+        if re.fullmatch(r"[0-9a-f]{40,64}", head):
+            result["HEAD"] = head
+        return result
+
+    def _new_commits(
+        self, path: Path, current: dict[str, str], previous: dict[str, str]
+    ) -> list[dict[str, Any]]:
+        new_tips = sorted(set(current.values()))
+        old_tips = [
+            value
+            for value in sorted(set(previous.values()))
+            if re.fullmatch(r"[0-9a-f]{40,64}", str(value))
+            and self._commit_exists(path, str(value))
+        ]
+        arguments = ["rev-list", "--topo-order", "--max-count=10000", *new_tips]
+        if old_tips:
+            arguments.extend(["--not", *old_tips])
+        hashes = [
+            value
+            for value in self._git(path, *arguments, check=False).splitlines()
+            if re.fullmatch(r"[0-9a-f]{40,64}", value)
+        ]
+        return [record for commit in hashes if (record := self._commit(path, commit)) is not None]
+
+    def _commit(self, path: Path, commit: str) -> dict[str, Any] | None:
+        output = self._git(
+            path,
+            "show",
+            "--format=%H%x00%ct%x00%P",
+            "--numstat",
+            "--no-renames",
+            "--no-color",
+            commit,
+            check=False,
+        )
+        lines = output.splitlines()
+        if not lines:
+            return None
+        header = lines[0].split("\x00")
+        if len(header) != 3 or header[0] != commit or not header[1].isdigit():
+            return None
+        parents = header[2].split()
+        aggregate = (
+            {"additions": 0, "deletions": 0, "files": 0, "binary": 0}
+            if len(parents) > 1
+            else _numstat(lines[1:])
+        )
+        return {
+            "sha": commit,
+            "committed_at": datetime.fromtimestamp(int(header[1]), UTC).isoformat(),
+            "additions": aggregate["additions"],
+            "deletions": aggregate["deletions"],
+            "files_changed": aggregate["files"],
+            "binary_files": aggregate["binary"],
+            "is_merge": len(parents) > 1,
+        }
+
+    def _worktree(self, path: Path) -> dict[str, int]:
+        staged = _numstat(
+            self._git_bytes(path, "diff", "--cached", "--numstat", "-z", "--no-renames", "--")
+            .decode(errors="replace")
+            .split("\x00")
+        )
+        unstaged = _numstat(
+            self._git_bytes(path, "diff", "--numstat", "-z", "--no-renames", "--")
+            .decode(errors="replace")
+            .split("\x00")
+        )
+        return {
+            "staged_additions": staged["additions"],
+            "staged_deletions": staged["deletions"],
+            "staged_files": staged["files"],
+            "unstaged_additions": unstaged["additions"],
+            "unstaged_deletions": unstaged["deletions"],
+            "unstaged_files": unstaged["files"],
+            "binary_files": staged["binary"] + unstaged["binary"],
+        }
+
+    def _git(self, path: Path, *arguments: str, check: bool = True) -> str:
+        return self._git_bytes(path, *arguments, check=check).decode(errors="replace").strip()
+
+    def _commit_exists(self, path: Path, value: str) -> bool:
+        try:
+            self._git_bytes(path, "cat-file", "-e", f"{value}^{{commit}}")
+        except subprocess.CalledProcessError:
+            return False
+        return True
+
+    @staticmethod
+    def _git_bytes(path: Path, *arguments: str, check: bool = True) -> bytes:
+        environment = dict(os.environ)
+        environment["GIT_OPTIONAL_LOCKS"] = "0"
+        result = subprocess.run(  # noqa: S603 - fixed Git collector command
+            ["git", "-C", str(path), *arguments],  # noqa: S607 - packaged executable
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=20,
+            env=environment,
+        )
+        if check and result.returncode != 0:
+            raise subprocess.CalledProcessError(result.returncode, "git")
+        return result.stdout
+
+
+def sanitize_otlp(payload: object, maximum_points: int) -> tuple[dict[str, Any], int]:
+    """Reduce OTLP/JSON to metric names, numeric points, and allowlisted dimensions."""
+    if not isinstance(payload, dict) or not isinstance(payload.get("resourceMetrics"), list):
+        raise PayloadError("invalid metrics")
+    resources: list[dict[str, Any]] = []
+    point_count = 0
+    for resource_metric in payload["resourceMetrics"]:
+        if not isinstance(resource_metric, dict) or not isinstance(
+            resource_metric.get("scopeMetrics"), list
+        ):
+            raise PayloadError("invalid metrics")
+        scopes: list[dict[str, Any]] = []
+        for scope_metric in resource_metric["scopeMetrics"]:
+            if not isinstance(scope_metric, dict) or not isinstance(
+                scope_metric.get("metrics"), list
+            ):
+                raise PayloadError("invalid metrics")
+            metrics: list[dict[str, Any]] = []
+            for candidate in scope_metric["metrics"]:
+                metric, points = _metric(candidate)
+                point_count += points
+                if point_count > maximum_points:
+                    raise PayloadError("too many metrics")
+                if points:
+                    metrics.append(metric)
+            if metrics:
+                scope: dict[str, Any] = {"metrics": metrics}
+                safe_scope = _scope(scope_metric.get("scope"))
+                if safe_scope:
+                    scope["scope"] = safe_scope
+                scopes.append(scope)
+        if scopes:
+            resource: dict[str, Any] = {"scopeMetrics": scopes}
+            attributes = _attributes(
+                (resource_metric.get("resource") or {}).get("attributes", []),
+                resource=True,
+            )
+            if attributes:
+                resource["resource"] = {"attributes": attributes}
+            resources.append(resource)
+    if not resources or point_count == 0:
+        raise PayloadError("empty metrics")
+    return {"resourceMetrics": resources}, point_count
+
+
+def _metric(candidate: object) -> tuple[dict[str, Any], int]:
+    if not isinstance(candidate, dict):
+        raise PayloadError("invalid metric")
+    name = candidate.get("name")
+    if not isinstance(name, str) or not SAFE_NAME.fullmatch(name):
+        raise PayloadError("invalid metric")
+    result: dict[str, Any] = {"name": name}
+    unit = candidate.get("unit")
+    if isinstance(unit, str) and (not unit or SAFE_VALUE.fullmatch(unit)):
+        result["unit"] = unit
+    count = 0
+    for form in ("gauge", "sum", "histogram", "exponentialHistogram", "summary"):
+        source = candidate.get(form)
+        if source is None:
+            continue
+        if not isinstance(source, dict) or not isinstance(source.get("dataPoints"), list):
+            raise PayloadError("invalid metric")
+        points = [_point(item) for item in source["dataPoints"]]
+        count += len(points)
+        data: dict[str, Any] = {"dataPoints": points}
+        if form in {"sum", "histogram", "exponentialHistogram"} and source.get(
+            "aggregationTemporality"
+        ) in {0, 1, 2, "0", "1", "2"}:
+            data["aggregationTemporality"] = int(source["aggregationTemporality"])
+        if form == "sum" and isinstance(source.get("isMonotonic"), bool):
+            data["isMonotonic"] = source["isMonotonic"]
+        result[form] = data
+    return result, count
+
+
+def _point(candidate: object) -> dict[str, Any]:
+    if not isinstance(candidate, dict):
+        raise PayloadError("invalid point")
+    result: dict[str, Any] = {}
+    attributes = _attributes(candidate.get("attributes", []), resource=False)
+    if attributes:
+        result["attributes"] = attributes
+    for key in POINT_SCALARS:
+        if key in candidate:
+            result[key] = _number(candidate[key])
+    for key in POINT_ARRAYS:
+        if key in candidate:
+            values = candidate[key]
+            if not isinstance(values, list) or len(values) > 20_000:
+                raise PayloadError("invalid point")
+            result[key] = [_number(value) for value in values]
+    for key in ("positive", "negative"):
+        if key in candidate:
+            value = candidate[key]
+            if not isinstance(value, dict) or not isinstance(value.get("bucketCounts", []), list):
+                raise PayloadError("invalid point")
+            result[key] = {
+                "offset": _number(value.get("offset", 0)),
+                "bucketCounts": [_number(item) for item in value.get("bucketCounts", [])],
+            }
+    if "quantileValues" in candidate:
+        values = candidate["quantileValues"]
+        if not isinstance(values, list) or len(values) > 10_000:
+            raise PayloadError("invalid point")
+        result["quantileValues"] = [
+            {"quantile": _number(item.get("quantile")), "value": _number(item.get("value"))}
+            for item in values
+            if isinstance(item, dict)
+        ]
+    if not any(key in result for key in ("asInt", "asDouble", "sum", "count")):
+        raise PayloadError("invalid point")
+    return result
+
+
+def _attributes(candidate: object, resource: bool) -> list[dict[str, Any]]:
+    if not isinstance(candidate, list):
+        return []
+    result: dict[str, dict[str, Any]] = {}
+    for item in candidate:
+        if not isinstance(item, dict) or not isinstance(item.get("key"), str):
+            continue
+        original = item["key"]
+        key = (
+            original
+            if resource and original in RESOURCE_ATTRIBUTES
+            else ATTRIBUTE_ALIASES.get(original)
+        )
+        if not key:
+            continue
+        value = _any_value(item.get("value"))
+        if value is not None:
+            result[key] = {"key": key, "value": value}
+    return [result[key] for key in sorted(result)]
+
+
+def _any_value(candidate: object) -> dict[str, Any] | None:
+    if not isinstance(candidate, dict):
+        return None
+    if isinstance(candidate.get("boolValue"), bool):
+        return {"boolValue": candidate["boolValue"]}
+    for key in ("intValue", "doubleValue"):
+        if key in candidate:
+            return {key: _number(candidate[key])}
+    value = candidate.get("stringValue")
+    if isinstance(value, str) and SAFE_VALUE.fullmatch(value):
+        return {"stringValue": value}
+    return None
+
+
+def _scope(candidate: object) -> dict[str, str] | None:
+    if not isinstance(candidate, dict):
+        return None
+    result = {
+        key: value
+        for key in ("name", "version")
+        if isinstance((value := candidate.get(key)), str) and SAFE_VALUE.fullmatch(value)
+    }
+    return result or None
+
+
+def _number(value: object) -> int | float | str:
+    if isinstance(value, bool):
+        raise PayloadError("invalid number")
+    if isinstance(value, float) and not math.isfinite(value):
+        raise PayloadError("invalid number")
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, str) and re.fullmatch(r"-?[0-9]{1,30}(?:\.[0-9]+)?", value):
+        return value
+    raise PayloadError("invalid number")
+
+
+def _numstat(lines: list[str]) -> dict[str, int]:
+    result = {"additions": 0, "deletions": 0, "files": 0, "binary": 0}
+    for line in lines:
+        fields = line.split("\t", 2)
+        if len(fields) != 3:
+            continue
+        result["files"] += 1
+        if fields[0] == "-" or fields[1] == "-":
+            result["binary"] += 1
+            continue
+        if fields[0].isdigit() and fields[1].isdigit():
+            result["additions"] += int(fields[0])
+            result["deletions"] += int(fields[1])
+    return result
+
+
+def _github_remote(remote: str) -> str | None:
+    candidate = remote.strip()
+    if not candidate:
+        return None
+    if candidate.startswith("git@github.com:"):
+        path = candidate.removeprefix("git@github.com:")
+    else:
+        parsed = urllib.parse.urlsplit(candidate)
+        if (parsed.hostname or "").lower() != "github.com":
+            return None
+        path = parsed.path.lstrip("/")
+    path = path.removesuffix(".git")
+    if re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", path):
+        return f"github.com/{path}".lower()
+    return None
+
+
+def _remote_seed(remote: str) -> str | None:
+    candidate = remote.strip()
+    if not candidate:
+        return None
+    parsed = urllib.parse.urlsplit(candidate)
+    if parsed.hostname:
+        try:
+            parsed_port = parsed.port
+        except ValueError:
+            return None
+        port = f":{parsed_port}" if parsed_port else ""
+        path = parsed.path.rstrip("/").removesuffix(".git")
+        return f"{parsed.hostname.lower()}{port}{path}"
+    scp = re.fullmatch(r"(?:[^@/:]+@)?([^/:]+):(.+)", candidate)
+    if scp:
+        host, path = scp.groups()
+        return f"{host.lower()}:{path.rstrip('/').removesuffix('.git')}"
+    return None
+
+
+def heartbeat(outbox: Outbox, stopped: threading.Event) -> None:
+    while not stopped.is_set():
+        outbox.enqueue("heartbeat", {"observed_at": now_text()}, 0)
+        stopped.wait(60)
+
+
+def canonical(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def now_text() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def positive_environment(name: str, default: int, maximum: int) -> int:
+    try:
+        value = int(os.environ.get(name, str(default)))
+    except ValueError:
+        return default
+    return value if 1 <= value <= maximum else default
+
+
+def run_agent() -> None:
+    endpoint = os.environ["DEVBOXES_INSIGHTS_ENDPOINT"]
+    credential = os.environ["DEVBOXES_INSIGHTS_CREDENTIAL"]
+    outbox_path = Path(
+        os.environ.get(
+            "DEVBOXES_INSIGHTS_OUTBOX",
+            "/home/dev/.devbox/insights/outbox.db",
+        )
+    )
+    maximum_bytes = positive_environment(
+        "DEVBOXES_INSIGHTS_MAX_QUEUE_BYTES", 134_217_728, 2_147_483_648
+    )
+    maximum_age = positive_environment(
+        "DEVBOXES_INSIGHTS_MAX_QUEUE_AGE_SECONDS", 604_800, 31_536_000
+    )
+    scan_interval = positive_environment("DEVBOXES_INSIGHTS_SCAN_INTERVAL_SECONDS", 60, 3600)
+    depth = positive_environment("DEVBOXES_INSIGHTS_REPOSITORY_DEPTH", 4, 12)
+    outbox = Outbox(outbox_path, maximum_bytes, maximum_age)
+    MetricsHandler.outbox = outbox
+    server = ThreadingHTTPServer(("127.0.0.1", 4318), MetricsHandler)
+    stopped = threading.Event()
+    threads = [
+        threading.Thread(
+            target=Sender(outbox, endpoint, credential).run, args=(stopped,), daemon=True
+        ),
+        threading.Thread(
+            target=GitCollector(outbox, Path("/home/dev/workspace"), depth).run,
+            args=(stopped, scan_interval),
+            daemon=True,
+        ),
+        threading.Thread(target=heartbeat, args=(outbox, stopped), daemon=True),
+    ]
+    try:
+        for thread in threads:
+            thread.start()
+        server.serve_forever(poll_interval=0.5)
+    finally:
+        stopped.set()
+        server.server_close()
+
+
+def main() -> None:
+    """Keep SSH fail-open while retrying recoverable collector initialization."""
+    while True:
+        try:
+            run_agent()
+        except Exception as error:  # The main workspace must remain reachable if Insights fails.
+            print(
+                f"[insights] collector unavailable, retrying: {type(error).__name__}",
+                flush=True,
+            )
+            time.sleep(RESTART_DELAY_SECONDS)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add opt-in, privacy-bounded Devboxes Insights for Codex/Claude telemetry and aggregate Git activity
- add durable SQLite storage, scoped workspace ingest credentials, outboxes, backups, retention, export, and purge
- add responsive dashboard, CLI metrics workflows, Helm contracts, documentation, and end-to-end lifecycle coverage
- prepare the repository for v0.3.0

## Validation

- `make lint`
- `make test` (129 controller tests, 88.86% coverage; 17 CLI tests)
- `make helm`
- `make images`
- clean Kind lifecycle: ingest, dedupe, Git baseline/delta, CLI/dashboard APIs, backup, SSH/tmux, controller/workspace restart, retained PVC/history, recreate, and purge
- Gitleaks staged diff scan