### PR TITLE
feat: add configurable GPU acceleration profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to Devboxes are documented here. The project follows [Keep a
 
 ## [Unreleased]
 
+### Added
+
+- Added opt-in, operator-approved GPU profiles across Helm, the API, CLI, dashboard, and in-product documentation, including default and explicitly named profile selection.
+- Added portable extended-resource requests for NVIDIA, AMD, Intel, partitioned, shared, device-plugin, and compatible Dynamic Resource Allocation bridge configurations, with optional per-profile workspace images, RuntimeClasses, supplemental groups, node selectors, and tolerations.
+- Added authenticated installation capability discovery, GPU allocation reporting, scheduler diagnostics, strict chart and controller validation, Helm contract tests, and end-to-end controller coverage.
+
+### Changed
+
+- Persist the fully resolved GPU profile on each workspace so stop, start, and Insights reconciliation cannot silently change or remove an existing hardware allocation after Helm configuration changes.
+- Show accelerator allocation in CLI list and status output and in the browser workbench while keeping CPU-only creation as the default.
+
+### Fixed
+
+- Made the Insights HTTP integration fixture use the current observation time so the full controller suite remains deterministic after its original fixture date.
+
+### Security
+
+- Restrict clients to named operator-owned profiles instead of accepting arbitrary images, resource names, RuntimeClasses, supplemental groups, selectors, tolerations, privileged mode, or host mounts.
+
 ## [0.3.0] - 2026-07-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Devboxes are documented here. The project follows [Keep a
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-07-20
+
 ### Added
 
 - Added opt-in, operator-approved GPU profiles across Helm, the API, CLI, dashboard, and in-product documentation, including default and explicitly named profile selection.
@@ -109,7 +111,8 @@ All notable changes to Devboxes are documented here. The project follows [Keep a
 - Portable Helm chart with values schema, namespace-scoped RBAC, configurable storage, ingress, LoadBalancer or NodePort SSH, ServiceMonitor, and disruption budget.
 - macOS and Linux CLI releases, SHA-256 verification installer, GHCR images, OCI chart publishing, image provenance attestations, and clean Kind install CI.
 
-[Unreleased]: https://github.com/vicotrbb/devboxes/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/vicotrbb/devboxes/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/vicotrbb/devboxes/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/vicotrbb/devboxes/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/vicotrbb/devboxes/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/vicotrbb/devboxes/compare/v0.1.2...v0.2.0

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ test:
 
 helm:
 	scripts/test-helm-insights.sh
+	scripts/test-helm-gpu.sh
 	helm template devboxes charts/devboxes --namespace devboxes --set workspace.sshService.type=NodePort --set workspace.sshService.host=192.0.2.10 >/dev/null
 
 images:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Each workspace includes Rust, Node.js, Python, `uv`, GitHub CLI, Codex CLI, Clau
 - A Rust `devbox` CLI for create, list, inspect, SSH, start, stop, delete, and opt-in Insights workflows.
 - A FastAPI controller with an authenticated API, accessible browser workbench, Insights dashboard, documentation, metrics, health checks, and TTL cleanup.
 - A versioned Helm chart with values schema validation and namespace-scoped RBAC.
+- Optional operator-approved GPU profiles for NVIDIA, AMD, Intel, partitioned, or shared accelerators.
 - Multi-architecture controller and workspace images for `linux/amd64` and `linux/arm64`.
 - Persistent SSH host identity, shell state, tool installs, account state, and source under `/home/dev`.
 - GitHub Releases with macOS and Linux CLI binaries and SHA-256 checksums.
@@ -39,6 +40,8 @@ Devboxes is currently a single-operator system: one shared token controls every 
   - reachable Kubernetes nodes and `workspace.sshService.type=NodePort`.
 - An SSH public key.
 - An ingress controller and TLS certificate only if you expose the dashboard through ingress. Port-forwarding works without either.
+
+GPU acceleration additionally requires GPU nodes, a working vendor device plugin or a Dynamic Resource Allocation driver with a compatible extended-resource bridge, and a workspace image containing the user-space libraries needed by the workload. GPU support is opt-in and CPU-only remains the safe default.
 
 The workspace container intentionally supports passwordless `sudo` for the trusted development user. Its pod drops all capabilities and adds back a small set needed by `sudo` and OpenSSH PTY auditing, but it is not compatible with the Kubernetes `restricted` Pod Security profile. Use the `baseline` profile or an equivalent policy in the Devboxes namespace.
 
@@ -132,6 +135,40 @@ For clusters without a load balancer, let Kubernetes allocate a distinct NodePor
 
 See [configuration](docs/configuration.md) for every supported value and platform examples.
 
+### Enable GPU acceleration
+
+Operators expose trusted, named profiles instead of allowing clients to inject Kubernetes pod fields. Each profile binds a user-facing name to an extended resource, count, optional GPU-ready workspace image, and optional scheduling policy:
+
+```yaml
+gpu:
+  enabled: true
+  defaultProfile: nvidia-l4
+  profiles:
+    - name: nvidia-l4
+      displayName: NVIDIA L4
+      description: One dedicated L4 for inference and CUDA development
+      resourceName: nvidia.com/gpu
+      count: 1
+      workspaceImage: ghcr.io/example/devboxes-workspace-cuda:12.8
+      runtimeClassName: nvidia
+      nodeSelector:
+        accelerator: nvidia-l4
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+```
+
+After upgrading the release with this values file, users can discover and request profiles through every supported interface:
+
+```bash
+devbox gpu profiles
+devbox create inference --gpu --ssh
+devbox create training --gpu-profile nvidia-l4 --preset large --ssh
+```
+
+The dashboard exposes the same profiles in its create form. Devboxes sets the resource in both container requests and limits, preserves the resolved allocation across stop and start, and surfaces scheduler reasons when capacity is unavailable. Read [GPU acceleration](docs/gpu.md) for driver prerequisites, NVIDIA and AMD examples, image contracts, sharing, security, upgrades, and troubleshooting.
+
 ### Enable Insights
 
 Insights is disabled by default. Enable it to collect privacy-bounded local AI metrics and aggregate Git activity into a persistent controller database:
@@ -178,6 +215,7 @@ Authenticate and create a box:
 ```bash
 devbox login --url https://devboxes.example.com
 devbox create atlas --preset medium --ttl 24 --repo owner/project --ssh
+devbox create inference --gpu --ssh
 ```
 
 Login opens the system browser, asks the current Devboxes browser session to approve the
@@ -247,7 +285,7 @@ devbox CLI / browser
 Devboxes controller ─── Kubernetes API
           │                  │
           │                  ├─ Secret (scoped Insights ingest credential)
-          │                  ├─ Deployment (disposable compute)
+          │                  ├─ Deployment (disposable CPU or GPU compute)
           │                  ├─ Service (LoadBalancer or NodePort SSH)
           │                  └─ PVC (persistent /home/dev)
           ├─ TTL cleanup and lifecycle state
@@ -274,6 +312,7 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md) before proposing a change. Security repo
 
 - [Golden path](docs/golden-path.md) for a performance-oriented installation and daily workflow.
 - [CLI reference](docs/cli.md) and [API reference](docs/api.md) for client contracts.
+- [GPU acceleration](docs/gpu.md) for accelerator profiles, images, scheduling, and operations.
 - [Insights](docs/insights.md) for telemetry semantics, privacy, storage, backup, and purge.
 - [Configuration](docs/configuration.md) and [credentials](docs/credentials.md) for installation details.
 - [Operations](docs/operations.md) and [troubleshooting](docs/troubleshooting.md) for production ownership.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ kubectl -n devboxes create secret generic devboxes-workspace \
   --from-file=SSH_AUTHORIZED_KEYS="$HOME/.ssh/id_ed25519.pub"
 
 helm install devboxes oci://ghcr.io/vicotrbb/charts/devboxes \
-  --version 0.3.0 \
+  --version 0.4.0 \
   --namespace devboxes
 ```
 
@@ -320,7 +320,7 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md) before proposing a change. Security repo
 
 ## Project status
 
-Devboxes is at `v0.3`: useful and installable, with an intentionally narrow trust model. Compatibility follows semantic versioning after `v1.0`; before then, minor releases may include documented configuration or API changes. PVC data is never automatically deleted, including at TTL expiry.
+Devboxes is at `v0.4`: useful and installable, with an intentionally narrow trust model. Compatibility follows semantic versioning after `v1.0`; before then, minor releases may include documented configuration or API changes. PVC data is never automatically deleted, including at TTL expiry.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,6 +28,7 @@ Recommended deployment controls:
 - use fine-grained, least-privilege provider tokens;
 - enable Kubernetes Secret encryption at rest and an auditable secret manager;
 - enforce the chart's namespace-scoped RBAC and tokenless workspace service account;
+- expose GPU devices only through reviewed operator-owned profiles and trusted derived images;
 - back up important PVCs and test restore procedures;
 - keep Kubernetes, ingress, CSI, images, chart, and CLI releases current;
 - verify release checksums and image provenance attestations.
@@ -38,6 +39,8 @@ authorization codes, and expiring scoped tokens. It has no skip-TLS-verification
 Workspace SSH disables password, keyboard-interactive, and root login and uses persistent
 Ed25519 host keys. Incoming terminal names are validated against installed terminfo before
 tmux starts.
+
+GPU profiles preserve this trust model. Clients can select only a configured name; they cannot inject an image, extended resource, RuntimeClass, supplemental group, selector, toleration, privileged mode, host path, or device path. The assigned device is fully available to the trusted workspace user, including through passwordless `sudo`, so GPU profiles do not make Devboxes suitable for untrusted workloads. Vendor drivers, device plugins, runtimes, and derived GPU images are part of the operator's trusted supply chain.
 
 ## Dependency and supply-chain policy
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -11,8 +11,11 @@ kubectl get deployment,service,pvc,pod -n devboxes -o wide
 kubectl logs -n devboxes deployment/devboxes --tail=200
 kubectl get events -n devboxes --sort-by=.lastTimestamp
 devbox --version
+devbox gpu profiles
 ```
 
 For SSH problems, state whether the installation uses `LoadBalancer` or `NodePort`, whether the address is reachable from the CLI machine, and the exact OpenSSH error. For storage problems, include the StorageClass name, access mode, expansion support, and PVC events.
+
+For GPU problems, include the selected profile, redacted `devbox status` output, the pod's scheduling events, Kubernetes RuntimeClass presence, and the exact extended resource shown in node allocatable capacity. State whether the vendor plugin uses dedicated, partitioned, or shared devices. Do not include private registry credentials, image pull Secrets, public node addresses, or proprietary workload output.
 
 Security issues must follow [SECURITY.md](SECURITY.md) and must not be posted publicly.

--- a/charts/devboxes/Chart.yaml
+++ b/charts/devboxes/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: devboxes
 description: Self-hosted, ephemeral development environments on Kubernetes
 type: application
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.4.0
+appVersion: "0.4.0"
 kubeVersion: ">=1.29.0-0"
 home: https://github.com/vicotrbb/devboxes
 icon: https://raw.githubusercontent.com/vicotrbb/devboxes/main/docs/assets/devboxes-mark.svg
@@ -17,8 +17,8 @@ annotations:
   artifacthub.io/category: integration-delivery
   artifacthub.io/changes: |
     - kind: added
-      description: Add privacy-bounded Devboxes Insights for AI metrics and aggregate Git activity
+      description: Add operator-approved GPU profiles across Helm, API, CLI, and dashboard workflows
     - kind: added
-      description: Add dashboard and CLI summary, status, activity, export, and purge workflows
+      description: Add accelerator discovery, allocation reporting, and scheduler diagnostics
     - kind: security
-      description: Add dual allowlists and scoped per-workspace ingest credentials
+      description: Restrict users to named operator-owned hardware profiles and pinned workload contracts

--- a/charts/devboxes/templates/NOTES.txt
+++ b/charts/devboxes/templates/NOTES.txt
@@ -26,3 +26,11 @@ Devboxes is installed in namespace {{ .Release.Namespace }}.
 Important: every workspace needs an externally reachable SSH service. Configure
 workspace.sshService for your cluster's LoadBalancer implementation or use
 NodePort with workspace.sshService.host.
+{{- if .Values.gpu.enabled }}
+
+GPU acceleration is enabled with {{ len .Values.gpu.profiles }} operator-approved profile(s).
+Confirm the matching node drivers, device resources, runtimes, and workspace images,
+then inspect the user catalog with:
+
+   devbox gpu profiles
+{{- end }}

--- a/charts/devboxes/templates/deployment.yaml
+++ b/charts/devboxes/templates/deployment.yaml
@@ -1,6 +1,29 @@
 {{- if and .Values.insights.enabled (ne (int .Values.controller.replicaCount) 1) }}
 {{- fail "controller.replicaCount must be exactly 1 when insights.enabled=true" }}
 {{- end }}
+{{- $gpuProfileNames := dict }}
+{{- $gpuDefaultFound := false }}
+{{- range .Values.gpu.profiles }}
+{{- if hasKey $gpuProfileNames .name }}
+{{- fail (printf "gpu.profiles contains duplicate name %q" .name) }}
+{{- end }}
+{{- if not (trim .displayName) }}
+{{- fail (printf "gpu profile %q displayName must not be blank" .name) }}
+{{- end }}
+{{- if and .workspaceImage (contains "://" .workspaceImage) }}
+{{- fail (printf "gpu profile %q workspaceImage must not contain a URL scheme" .name) }}
+{{- end }}
+{{- $_ := set $gpuProfileNames .name true }}
+{{- if eq .name $.Values.gpu.defaultProfile }}
+{{- $gpuDefaultFound = true }}
+{{- end }}
+{{- end }}
+{{- if and .Values.gpu.defaultProfile (not $gpuDefaultFound) }}
+{{- fail "gpu.defaultProfile must name an entry in gpu.profiles" }}
+{{- end }}
+{{- if and .Values.gpu.enabled (not .Values.gpu.defaultProfile) }}
+{{- fail "gpu.defaultProfile is required when gpu.enabled=true" }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -99,6 +122,12 @@ spec:
             {{- end }}
             - name: DEVBOXES_LOG_LEVEL
               value: {{ .Values.controller.logLevel | quote }}
+            - name: DEVBOXES_GPU_ENABLED
+              value: {{ .Values.gpu.enabled | quote }}
+            - name: DEVBOXES_GPU_DEFAULT_PROFILE
+              value: {{ .Values.gpu.defaultProfile | quote }}
+            - name: DEVBOXES_GPU_PROFILES
+              value: {{ .Values.gpu.profiles | toJson | quote }}
             - name: DEVBOXES_INSIGHTS_ENABLED
               value: {{ .Values.insights.enabled | quote }}
             {{- if .Values.insights.enabled }}

--- a/charts/devboxes/values.schema.json
+++ b/charts/devboxes/values.schema.json
@@ -76,6 +76,94 @@
         }
       }
     },
+    "gpu": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "defaultProfile", "profiles"],
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "defaultProfile": {
+          "type": "string",
+          "maxLength": 40,
+          "pattern": "^(?:[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?)?$"
+        },
+        "profiles": {
+          "type": "array",
+          "maxItems": 32,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "displayName", "resourceName", "count"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 40,
+                "pattern": "^[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?$"
+              },
+              "displayName": {"type": "string", "minLength": 1, "maxLength": 80},
+              "description": {"type": "string", "maxLength": 160},
+              "resourceName": {
+                "type": "string",
+                "minLength": 3,
+                "maxLength": 317,
+                "pattern": "^[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?(?:\\.[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?)*/[A-Za-z0-9](?:[-_.A-Za-z0-9]{0,61}[A-Za-z0-9])?$"
+              },
+              "count": {"type": "integer", "minimum": 1, "maximum": 64},
+              "workspaceImage": {
+                "type": "string",
+                "maxLength": 512,
+                "pattern": "^(?:[^[:space:]]+)?$"
+              },
+              "runtimeClassName": {
+                "type": "string",
+                "maxLength": 253,
+                "pattern": "^(?:[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?(?:\\.[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?)*)?$"
+              },
+              "supplementalGroups": {
+                "type": "array",
+                "maxItems": 8,
+                "uniqueItems": true,
+                "items": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 2147483647
+                }
+              },
+              "nodeSelector": {
+                "type": "object",
+                "maxProperties": 16,
+                "propertyNames": {
+                  "maxLength": 317,
+                  "pattern": "^(?:[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?(?:\\.[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?)*/)?[A-Za-z0-9](?:[-_.A-Za-z0-9]{0,61}[A-Za-z0-9])?$"
+                },
+                "additionalProperties": {
+                  "type": "string",
+                  "maxLength": 63,
+                  "pattern": "^(?:[A-Za-z0-9](?:[-_.A-Za-z0-9]{0,61}[A-Za-z0-9])?)?$"
+                }
+              },
+              "tolerations": {
+                "type": "array",
+                "maxItems": 16,
+                "items": {"$ref": "#/definitions/gpuToleration"}
+              }
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"enabled": {"const": true}}},
+          "then": {
+            "properties": {
+              "defaultProfile": {"minLength": 1},
+              "profiles": {"minItems": 1}
+            }
+          }
+        }
+      ]
+    },
     "insights": {
       "type": "object",
       "additionalProperties": false,
@@ -185,6 +273,63 @@
         "repository": {"type": "string", "minLength": 1},
         "tag": {"type": "string"}
       }
+    },
+    "gpuToleration": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "type": "string",
+          "maxLength": 317,
+          "pattern": "^(?:(?:[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?(?:\\.[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?)*/)?[A-Za-z0-9](?:[-_.A-Za-z0-9]{0,61}[A-Za-z0-9])?)?$"
+        },
+        "operator": {"type": "string", "enum": ["Equal", "Exists"]},
+        "value": {
+          "type": "string",
+          "maxLength": 63,
+          "pattern": "^(?:[A-Za-z0-9](?:[-_.A-Za-z0-9]{0,61}[A-Za-z0-9])?)?$"
+        },
+        "effect": {
+          "type": "string",
+          "enum": ["NoSchedule", "PreferNoSchedule", "NoExecute"]
+        },
+        "tolerationSeconds": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 2147483647
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {"operator": {"const": "Exists"}},
+            "required": ["operator"]
+          },
+          "then": {"not": {"required": ["value"]}}
+        },
+        {
+          "if": {
+            "anyOf": [
+              {"not": {"required": ["operator"]}},
+              {
+                "properties": {"operator": {"const": "Equal"}},
+                "required": ["operator"]
+              }
+            ]
+          },
+          "then": {
+            "required": ["key"],
+            "properties": {"key": {"minLength": 1}}
+          }
+        },
+        {
+          "if": {"required": ["tolerationSeconds"]},
+          "then": {
+            "required": ["effect"],
+            "properties": {"effect": {"const": "NoExecute"}}
+          }
+        }
+      ]
     }
   }
 }

--- a/charts/devboxes/values.yaml
+++ b/charts/devboxes/values.yaml
@@ -57,6 +57,28 @@ workspace:
     externalTrafficPolicy: Cluster
     loadBalancerSourceRanges: []
 
+# GPU acceleration is opt-in. Each profile maps a stable user-facing name to
+# one device-plugin or DRA-bridged extended resource and trusted scheduling policy.
+gpu:
+  enabled: false
+  defaultProfile: ""
+  # Example profile fields:
+  # - name: nvidia-l4
+  #   displayName: NVIDIA L4
+  #   description: One dedicated GPU
+  #   resourceName: nvidia.com/gpu
+  #   count: 1
+  #   workspaceImage: registry.example/devboxes-workspace-cuda:12.8
+  #   runtimeClassName: nvidia
+  #   supplementalGroups: []
+  #   nodeSelector:
+  #     accelerator: nvidia-l4
+  #   tolerations:
+  #     - key: nvidia.com/gpu
+  #       operator: Exists
+  #       effect: NoSchedule
+  profiles: []
+
 insights:
   enabled: false
   # Optional key in controller.existingSecret. Empty derives a dedicated,

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "devbox-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devbox-cli"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.96"
 description = "Terminal client for self-hosted Kubernetes development environments"

--- a/cli/README.md
+++ b/cli/README.md
@@ -6,6 +6,8 @@ The `devbox` terminal client creates, inspects, connects to, stops, and deletes 
 cargo install --locked --git https://github.com/vicotrbb/devboxes devbox-cli
 devbox login --url https://devboxes.example.com
 devbox create atlas --repo owner/project --ssh
+devbox gpu profiles
+devbox create inference --gpu --ssh
 ```
 
-See the [CLI reference](../docs/cli.md) for every command, option, environment variable, output contract, and SSH workflow. The [golden path](../docs/golden-path.md) covers the recommended installation and performance setup.
+See the [CLI reference](../docs/cli.md) for every command, option, environment variable, output contract, and SSH workflow. [GPU acceleration](../docs/gpu.md) covers operator-approved accelerator profiles. The [golden path](../docs/golden-path.md) covers the recommended installation and performance setup.

--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -7,8 +7,8 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 
 use crate::models::{
-    CliTokenRequest, CliTokenResponse, CreateDevbox, DeleteResult, Devbox, DevboxList,
-    InsightsActivityData, InsightsEnvelope, InsightsPurgeResult, InsightsStatusData,
+    Capabilities, CliTokenRequest, CliTokenResponse, CreateDevbox, DeleteResult, Devbox,
+    DevboxList, InsightsActivityData, InsightsEnvelope, InsightsPurgeResult, InsightsStatusData,
     InsightsSummary, WhoAmI,
 };
 
@@ -51,6 +51,11 @@ impl ApiClient {
 
     pub async fn whoami(&self) -> Result<WhoAmI> {
         self.request(Method::GET, "/api/v1/whoami", Option::<&()>::None)
+            .await
+    }
+
+    pub async fn capabilities(&self) -> Result<Capabilities> {
+        self.request(Method::GET, "/api/v1/capabilities", Option::<&()>::None)
             .await
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -16,8 +16,8 @@ use tokio::time::{Instant, sleep};
 use client::ApiClient;
 use config::StoredConfig;
 use models::{
-    CollectorStatus, CreateDevbox, Devbox, InsightsActivity, InsightsActivityData,
-    InsightsEnvelope, InsightsStatusData, InsightsSummary, Preset,
+    CollectorStatus, CreateDevbox, Devbox, GpuCapabilities, GpuRequest, InsightsActivity,
+    InsightsActivityData, InsightsEnvelope, InsightsStatusData, InsightsSummary, Preset,
 };
 
 #[derive(Parser)]
@@ -63,6 +63,8 @@ enum Commands {
     Delete(DeleteArgs),
     /// Inspect privacy-preserving AI and repository metrics.
     Metrics(MetricsArgs),
+    /// Inspect GPU acceleration profiles configured by the operator.
+    Gpu(GpuArgs),
 }
 
 #[derive(Args)]
@@ -92,6 +94,14 @@ struct CreateArgs {
     #[arg(long)]
     repo: Option<String>,
 
+    /// Request the operator's default GPU profile.
+    #[arg(long)]
+    gpu: bool,
+
+    /// Request a specific operator-approved GPU profile (implies --gpu).
+    #[arg(long, value_name = "PROFILE", value_parser = validate_name)]
+    gpu_profile: Option<String>,
+
     /// Return immediately instead of waiting for SSH readiness.
     #[arg(long)]
     no_wait: bool,
@@ -99,6 +109,18 @@ struct CreateArgs {
     /// Connect as soon as the devbox becomes ready.
     #[arg(long)]
     ssh: bool,
+}
+
+#[derive(Args)]
+struct GpuArgs {
+    #[command(subcommand)]
+    command: Option<GpuCommand>,
+}
+
+#[derive(Subcommand)]
+enum GpuCommand {
+    /// List the GPU profiles available for new devboxes.
+    Profiles,
 }
 
 #[derive(Args)]
@@ -249,6 +271,7 @@ async fn main() -> Result<()> {
         Commands::Stop(args) => lifecycle(&client, &args.name, false, cli.json).await,
         Commands::Delete(args) => delete(&client, args).await,
         Commands::Metrics(args) => metrics(&client, args, cli.json).await,
+        Commands::Gpu(args) => gpu(&client, args, cli.json).await,
     }
 }
 
@@ -358,11 +381,19 @@ async fn create(
     json: bool,
     server_alias: &str,
 ) -> Result<()> {
+    let gpu = if args.gpu || args.gpu_profile.is_some() {
+        Some(GpuRequest {
+            profile: args.gpu_profile.as_deref(),
+        })
+    } else {
+        None
+    };
     let payload = CreateDevbox {
         name: &args.name,
         preset: args.preset,
         ttl_hours: args.ttl,
         repository: args.repo.as_deref(),
+        gpu,
     };
     let mut box_info = client.create(&payload).await?;
     if !args.no_wait || args.ssh {
@@ -387,16 +418,17 @@ async fn list(client: &ApiClient, json: bool) -> Result<()> {
         return Ok(());
     }
     println!(
-        "{:<22} {:<11} {:<8} {:<16} SSH",
-        "NAME", "STATE", "SIZE", "AUTO-STOP"
+        "{:<22} {:<11} {:<8} {:<16} {:<18} SSH",
+        "NAME", "STATE", "SIZE", "AUTO-STOP", "ACCELERATOR"
     );
     for box_info in boxes {
         println!(
-            "{:<22} {:<11} {:<8} {:<16} {}",
+            "{:<22} {:<11} {:<8} {:<16} {:<18} {}",
             box_info.name,
             box_info.state,
             box_info.preset,
             human_expiry(&box_info),
+            gpu_label(&box_info),
             box_info.ssh_command.as_deref().unwrap_or("pending"),
         );
     }
@@ -520,6 +552,43 @@ async fn metrics(client: &ApiClient, args: MetricsArgs, json: bool) -> Result<()
         }
     }
     Ok(())
+}
+
+async fn gpu(client: &ApiClient, args: GpuArgs, json: bool) -> Result<()> {
+    let GpuArgs { command } = args;
+    match command {
+        None | Some(GpuCommand::Profiles) => {
+            let capabilities = client.capabilities().await?.gpu;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&capabilities)?);
+            } else {
+                print_gpu_profiles(&capabilities);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn print_gpu_profiles(capabilities: &GpuCapabilities) {
+    if !capabilities.enabled {
+        println!("GPU acceleration is disabled by the operator.");
+        return;
+    }
+    println!(
+        "{:<18} {:<26} {:>5} {:<28} DESCRIPTION",
+        "PROFILE", "NAME", "COUNT", "RESOURCE"
+    );
+    for profile in &capabilities.profiles {
+        println!(
+            "{:<18} {:<26} {:>5} {:<28} {}{}",
+            profile.name,
+            profile.display_name,
+            profile.count,
+            profile.resource_name,
+            profile.description.as_deref().unwrap_or(""),
+            if profile.is_default { " (default)" } else { "" },
+        );
+    }
 }
 
 fn metrics_query(filters: &MetricsFilters) -> Vec<(String, String)> {
@@ -706,7 +775,11 @@ async fn wait_until_ready(client: &ApiClient, name: &str, timeout: Duration) -> 
             );
         }
         if Instant::now() >= deadline {
-            bail!("timed out waiting for {name} to become ready");
+            let detail = box_info
+                .message
+                .as_deref()
+                .map_or_else(String::new, |message| format!(": {message}"));
+            bail!("timed out waiting for {name} to become ready{detail}");
         }
         sleep(Duration::from_secs(2)).await;
     }
@@ -768,6 +841,12 @@ fn print_box(box_info: &Devbox, json: bool) -> Result<()> {
     println!("{}  {}", box_info.name, box_info.state);
     println!("  preset:     {}", box_info.preset);
     println!("  storage:    {}", box_info.storage_size);
+    if let Some(gpu) = &box_info.gpu {
+        println!(
+            "  accelerator: {} ({} x {})",
+            gpu.display_name, gpu.count, gpu.resource_name
+        );
+    }
     println!("  auto-stop:  {}", box_info.expires_at.to_rfc3339());
     if let Some(repository) = &box_info.repository {
         println!("  repository: {repository}");
@@ -778,6 +857,13 @@ fn print_box(box_info: &Devbox, json: bool) -> Result<()> {
         println!("  status:     {message}");
     }
     Ok(())
+}
+
+fn gpu_label(box_info: &Devbox) -> &str {
+    box_info
+        .gpu
+        .as_ref()
+        .map_or("cpu", |gpu| gpu.profile.as_str())
 }
 
 fn human_expiry(box_info: &Devbox) -> String {
@@ -797,8 +883,8 @@ mod tests {
     use clap::Parser;
 
     use super::{
-        Cli, Commands, MetricsCommand, human_duration, metrics_query, resolve_login_token,
-        ssh_arguments, validate_name,
+        Cli, Commands, GpuCommand, MetricsCommand, human_duration, metrics_query,
+        resolve_login_token, ssh_arguments, validate_name,
     };
 
     #[test]
@@ -887,6 +973,51 @@ mod tests {
     fn metrics_rejects_unknown_providers_and_invalid_box_names() {
         assert!(Cli::try_parse_from(["devbox", "metrics", "--provider", "other"]).is_err());
         assert!(Cli::try_parse_from(["devbox", "metrics", "--box", "Invalid"]).is_err());
+    }
+
+    #[test]
+    fn create_accepts_default_and_named_gpu_profiles() {
+        let default_gpu = Cli::try_parse_from(["devbox", "create", "atlas", "--gpu"]).unwrap();
+        let Commands::Create(default_gpu) = default_gpu.command else {
+            panic!("expected create command");
+        };
+        assert!(default_gpu.gpu);
+        assert!(default_gpu.gpu_profile.is_none());
+
+        let named_gpu =
+            Cli::try_parse_from(["devbox", "create", "atlas", "--gpu-profile", "nvidia-l4"])
+                .unwrap();
+        let Commands::Create(named_gpu) = named_gpu.command else {
+            panic!("expected create command");
+        };
+        assert!(!named_gpu.gpu);
+        assert_eq!(named_gpu.gpu_profile.as_deref(), Some("nvidia-l4"));
+        assert!(
+            Cli::try_parse_from([
+                "devbox",
+                "create",
+                "atlas",
+                "--gpu-profile",
+                "Invalid_Profile",
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn gpu_profiles_command_is_discoverable() {
+        let root = Cli::try_parse_from(["devbox", "gpu"]).unwrap();
+        let Commands::Gpu(root) = root.command else {
+            panic!("expected gpu command");
+        };
+        assert!(root.command.is_none());
+
+        let profiles = Cli::try_parse_from(["devbox", "gpu", "profiles", "--json"]).unwrap();
+        assert!(profiles.json);
+        let Commands::Gpu(profiles) = profiles.command else {
+            panic!("expected gpu command");
+        };
+        assert!(matches!(profiles.command, Some(GpuCommand::Profiles)));
     }
 
     #[test]

--- a/cli/src/models.rs
+++ b/cli/src/models.rs
@@ -22,11 +22,27 @@ impl std::fmt::Display for Preset {
 }
 
 #[derive(Debug, Serialize)]
+pub struct GpuRequest<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<&'a str>,
+}
+
+#[derive(Debug, Serialize)]
 pub struct CreateDevbox<'a> {
     pub name: &'a str,
     pub preset: Preset,
     pub ttl_hours: u16,
     pub repository: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gpu: Option<GpuRequest<'a>>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct GpuAllocation {
+    pub profile: String,
+    pub display_name: String,
+    pub resource_name: String,
+    pub count: u16,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -45,6 +61,8 @@ pub struct Devbox {
     pub restarts: u32,
     pub storage_size: String,
     pub message: Option<String>,
+    #[serde(default)]
+    pub gpu: Option<GpuAllocation>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -61,6 +79,29 @@ pub struct DeleteResult {
 pub struct WhoAmI {
     pub user: String,
     pub mode: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Capabilities {
+    pub gpu: GpuCapabilities,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GpuCapabilities {
+    pub enabled: bool,
+    pub default_profile: Option<String>,
+    pub profiles: Vec<GpuProfileSummary>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GpuProfileSummary {
+    pub name: String,
+    pub display_name: String,
+    pub description: Option<String>,
+    pub resource_name: String,
+    pub count: u16,
+    #[serde(rename = "default")]
+    pub is_default: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -209,4 +250,81 @@ pub struct InsightsPurgeResult {
     #[serde(rename = "box")]
     pub box_name: String,
     pub purged_instances: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{CreateDevbox, Devbox, GpuRequest, Preset};
+
+    #[test]
+    fn create_payload_omits_cpu_only_gpu_state() {
+        let payload = CreateDevbox {
+            name: "atlas",
+            preset: Preset::Medium,
+            ttl_hours: 24,
+            repository: None,
+            gpu: None,
+        };
+
+        assert_eq!(
+            serde_json::to_value(payload).unwrap(),
+            json!({
+                "name": "atlas",
+                "preset": "medium",
+                "ttl_hours": 24,
+                "repository": null
+            })
+        );
+    }
+
+    #[test]
+    fn create_payload_distinguishes_default_and_named_gpu_profiles() {
+        let default_gpu = CreateDevbox {
+            name: "inference",
+            preset: Preset::Small,
+            ttl_hours: 24,
+            repository: None,
+            gpu: Some(GpuRequest { profile: None }),
+        };
+        let named_gpu = CreateDevbox {
+            name: "training",
+            preset: Preset::Large,
+            ttl_hours: 72,
+            repository: None,
+            gpu: Some(GpuRequest {
+                profile: Some("nvidia-l4"),
+            }),
+        };
+
+        assert_eq!(serde_json::to_value(default_gpu).unwrap()["gpu"], json!({}));
+        assert_eq!(
+            serde_json::to_value(named_gpu).unwrap()["gpu"],
+            json!({"profile": "nvidia-l4"})
+        );
+    }
+
+    #[test]
+    fn devbox_deserialization_accepts_pre_gpu_controller_responses() {
+        let box_info: Devbox = serde_json::from_value(json!({
+            "name": "atlas",
+            "state": "ready",
+            "preset": "medium",
+            "created_at": "2026-07-20T12:00:00Z",
+            "expires_at": "2026-07-21T12:00:00Z",
+            "repository": null,
+            "ssh_host": "192.0.2.10",
+            "ssh_port": 22,
+            "ssh_command": "ssh dev@192.0.2.10",
+            "pod_name": "devbox-atlas-example",
+            "pod_ready": true,
+            "restarts": 0,
+            "storage_size": "30Gi",
+            "message": null
+        }))
+        .unwrap();
+
+        assert!(box_info.gpu.is_none());
+    }
 }

--- a/controller/README.md
+++ b/controller/README.md
@@ -13,4 +13,4 @@ uv run pytest
 
 For local development, set `DEVBOXES_KUBECONFIG_CONTEXT` to a disposable Kubernetes context and provide a non-production `DEVBOXES_ACCESS_TOKEN`.
 
-See the [API reference](../docs/api.md), [architecture](../docs/architecture.md), and [operations runbook](../docs/operations.md) for supported behavior and deployment guidance.
+See the [API reference](../docs/api.md), [architecture](../docs/architecture.md), [GPU acceleration](../docs/gpu.md), and [operations runbook](../docs/operations.md) for supported behavior and deployment guidance.

--- a/controller/pyproject.toml
+++ b/controller/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "devboxes-controller"
-version = "0.3.0"
+version = "0.4.0"
 description = "Controller and dashboard for self-hosted Kubernetes development environments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/controller/src/devboxes_controller/__init__.py
+++ b/controller/src/devboxes_controller/__init__.py
@@ -1,3 +1,3 @@
 """Devboxes controller package."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/controller/src/devboxes_controller/app.py
+++ b/controller/src/devboxes_controller/app.py
@@ -49,12 +49,15 @@ from .insights_service import (
 from .insights_store import QueryFilters
 from .manager import DevboxConflictError, DevboxManager, DevboxNotFoundError
 from .models import (
+    Capabilities,
     CliTokenRequest,
     CliTokenResponse,
     CreateDevboxRequest,
     DeleteResult,
     Devbox,
     DevboxList,
+    GpuCapabilities,
+    GpuProfileSummary,
     WhoAmI,
 )
 from .resources import PRESETS
@@ -72,6 +75,28 @@ DevboxName = Annotated[
 ]
 
 
+def _capabilities(settings: Settings) -> Capabilities:
+    """Build the safe installation feature contract exposed to clients."""
+    return Capabilities(
+        gpu=GpuCapabilities(
+            enabled=settings.gpu_enabled,
+            default_profile=settings.gpu_default_profile if settings.gpu_enabled else None,
+            profiles=[
+                GpuProfileSummary(
+                    name=profile.name,
+                    display_name=profile.display_name,
+                    description=profile.description,
+                    resource_name=profile.resource_name,
+                    count=profile.count,
+                    default=profile.name == settings.gpu_default_profile,
+                )
+                for profile in settings.gpu_profiles
+                if settings.gpu_enabled
+            ],
+        )
+    )
+
+
 def create_app(
     settings: Settings | None = None,
     manager: DevboxManager | None = None,
@@ -87,6 +112,7 @@ def create_app(
         maximum_codes=settings.authorization_code_store_size,
     )
     templates = Jinja2Templates(directory=PACKAGE_DIR / "templates")
+    capabilities = _capabilities(settings)
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
@@ -372,6 +398,7 @@ def create_app(
                 "cluster_name": settings.cluster_name,
                 "storage_class": settings.storage_class or "cluster default",
                 "workspace_service_type": settings.workspace_service_type,
+                "gpu": capabilities.gpu,
                 "version": __version__,
             },
         )
@@ -416,6 +443,7 @@ def create_app(
                     for preset, resources in PRESETS.items()
                 ],
                 "insights_enabled": insights.enabled,
+                "gpu": capabilities.gpu,
                 "version": __version__,
             },
         )
@@ -423,6 +451,10 @@ def create_app(
     @app.get("/api/v1/whoami", tags=["auth"])
     async def whoami(auth: Auth) -> WhoAmI:
         return WhoAmI(user=auth.subject, mode=auth.mode)
+
+    @app.get("/api/v1/capabilities", tags=["system"])
+    async def installation_capabilities(_: Auth) -> Capabilities:
+        return capabilities
 
     @app.get("/api/v1/devboxes", tags=["devboxes"])
     async def list_devboxes(_: Auth) -> DevboxList:

--- a/controller/src/devboxes_controller/config.py
+++ b/controller/src/devboxes_controller/config.py
@@ -1,11 +1,189 @@
 """Validate controller configuration loaded from environment variables."""
 
+import re
 from functools import lru_cache
-from typing import Literal, Self
+from typing import Annotated, Literal, Self
 from urllib.parse import urlsplit
 
-from pydantic import Field, SecretStr, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+GPU_PROFILE_NAME_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?$")
+DNS_LABEL_RE = re.compile(r"^[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?$")
+QUALIFIED_NAME_PART_RE = re.compile(r"^[A-Za-z0-9](?:[-_.A-Za-z0-9]{0,61}[A-Za-z0-9])?$")
+LABEL_VALUE_RE = re.compile(r"^(?:[A-Za-z0-9](?:[-_.A-Za-z0-9]{0,61}[A-Za-z0-9])?)?$")
+SupplementalGroup = Annotated[int, Field(strict=True, ge=1, le=2_147_483_647)]
+
+
+def _valid_dns_subdomain(value: str) -> bool:
+    """Return whether a string follows Kubernetes DNS subdomain syntax."""
+    return 1 <= len(value) <= 253 and all(
+        DNS_LABEL_RE.fullmatch(label) for label in value.split(".")
+    )
+
+
+def _valid_qualified_name(value: str, *, require_prefix: bool) -> bool:
+    """Return whether a string follows Kubernetes qualified-name syntax."""
+    if "/" in value:
+        prefix, name = value.split("/", 1)
+        return bool(_valid_dns_subdomain(prefix) and QUALIFIED_NAME_PART_RE.fullmatch(name))
+    return not require_prefix and bool(QUALIFIED_NAME_PART_RE.fullmatch(value))
+
+
+class GpuToleration(BaseModel):
+    """Describe one operator-approved toleration applied to GPU workspaces."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
+
+    key: str | None = Field(default=None, max_length=317)
+    operator: Literal["Equal", "Exists"] = "Equal"
+    value: str | None = Field(default=None, max_length=63)
+    effect: Literal["NoSchedule", "PreferNoSchedule", "NoExecute"] | None = None
+    toleration_seconds: int | None = Field(
+        default=None,
+        alias="tolerationSeconds",
+        ge=0,
+        le=2_147_483_647,
+    )
+
+    @field_validator("key")
+    @classmethod
+    def key_is_qualified(cls, value: str | None) -> str | None:
+        """Validate a non-empty Kubernetes label key when supplied."""
+        if value is None or not value.strip():
+            return None
+        value = value.strip()
+        if not _valid_qualified_name(value, require_prefix=False):
+            raise ValueError("must be a valid Kubernetes label key")
+        return value
+
+    @field_validator("value")
+    @classmethod
+    def value_is_label_value(cls, value: str | None) -> str | None:
+        """Validate an optional Kubernetes label value."""
+        if value is None:
+            return None
+        value = value.strip()
+        if not LABEL_VALUE_RE.fullmatch(value):
+            raise ValueError("must be a valid Kubernetes label value")
+        return value or None
+
+    @model_validator(mode="after")
+    def fields_are_consistent(self) -> Self:
+        """Reject toleration combinations Kubernetes would treat ambiguously."""
+        if self.operator == "Equal" and self.key is None:
+            raise ValueError("Equal tolerations require a key")
+        if self.operator == "Exists" and self.value is not None:
+            raise ValueError("Exists tolerations cannot set a value")
+        if self.toleration_seconds is not None and self.effect != "NoExecute":
+            raise ValueError("tolerationSeconds requires effect=NoExecute")
+        return self
+
+
+class GpuProfile(BaseModel):
+    """Define one frozen, operator-approved GPU scheduling profile."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
+
+    name: str = Field(min_length=1, max_length=40)
+    display_name: str = Field(alias="displayName", min_length=1, max_length=80)
+    description: str | None = Field(default=None, max_length=160)
+    resource_name: str = Field(alias="resourceName", min_length=3, max_length=317)
+    count: int = Field(ge=1, le=64)
+    workspace_image: str | None = Field(default=None, alias="workspaceImage", max_length=512)
+    runtime_class_name: str | None = Field(
+        default=None,
+        alias="runtimeClassName",
+        max_length=253,
+    )
+    supplemental_groups: list[SupplementalGroup] = Field(
+        default_factory=list,
+        alias="supplementalGroups",
+        max_length=8,
+    )
+    node_selector: dict[str, str] = Field(default_factory=dict, alias="nodeSelector")
+    tolerations: list[GpuToleration] = Field(default_factory=list, max_length=16)
+
+    @field_validator("name")
+    @classmethod
+    def name_is_safe(cls, value: str) -> str:
+        """Require a compact profile identifier safe for API and CLI use."""
+        value = value.strip().lower()
+        if not GPU_PROFILE_NAME_RE.fullmatch(value):
+            raise ValueError(
+                "use 1-40 lowercase letters, digits, or hyphens; start and end alphanumeric"
+            )
+        return value
+
+    @field_validator("display_name")
+    @classmethod
+    def display_name_is_not_blank(cls, value: str) -> str:
+        """Normalize the user-visible profile label."""
+        value = value.strip()
+        if not value:
+            raise ValueError("must not be blank")
+        return value
+
+    @field_validator("description", "workspace_image", mode="before")
+    @classmethod
+    def optional_text_is_normalized(cls, value: object) -> object:
+        """Trim optional profile text and treat blank values as absent."""
+        if isinstance(value, str):
+            return value.strip() or None
+        return value
+
+    @field_validator("resource_name")
+    @classmethod
+    def resource_name_is_extended(cls, value: str) -> str:
+        """Require the vendor-qualified resource exposed by a device driver."""
+        value = value.strip()
+        if not _valid_qualified_name(value, require_prefix=True):
+            raise ValueError("must be a vendor-qualified Kubernetes extended resource")
+        return value
+
+    @field_validator("workspace_image")
+    @classmethod
+    def workspace_image_is_valid(cls, value: str | None) -> str | None:
+        """Reject image values Kubernetes cannot interpret as references."""
+        if value is not None and (
+            any(character.isspace() for character in value) or "://" in value
+        ):
+            raise ValueError(
+                "must be a whitespace-free container image reference without a URL scheme"
+            )
+        return value
+
+    @field_validator("runtime_class_name")
+    @classmethod
+    def runtime_class_name_is_dns_safe(cls, value: str | None) -> str | None:
+        """Validate an optional existing Kubernetes RuntimeClass name."""
+        if value is None or not value.strip():
+            return None
+        value = value.strip()
+        if not _valid_dns_subdomain(value):
+            raise ValueError("must be a valid Kubernetes DNS subdomain")
+        return value
+
+    @field_validator("supplemental_groups")
+    @classmethod
+    def supplemental_groups_are_unique(cls, value: list[int]) -> list[int]:
+        """Keep pod-level device group membership explicit and bounded."""
+        if len(value) != len(set(value)):
+            raise ValueError("must not contain duplicate group IDs")
+        return value
+
+    @field_validator("node_selector")
+    @classmethod
+    def node_selector_is_valid(cls, value: dict[str, str]) -> dict[str, str]:
+        """Validate bounded Kubernetes node selector terms."""
+        if len(value) > 16:
+            raise ValueError("must contain at most 16 entries")
+        for key, label_value in value.items():
+            if not _valid_qualified_name(key, require_prefix=False):
+                raise ValueError(f"invalid node selector key {key!r}")
+            if not LABEL_VALUE_RE.fullmatch(label_value):
+                raise ValueError(f"invalid node selector value for {key!r}")
+        return value
 
 
 class Settings(BaseSettings):
@@ -23,6 +201,9 @@ class Settings(BaseSettings):
     workspace_priority_class: str | None = None
     image_pull_secret: str | None = None
     storage_class: str | None = None
+    gpu_enabled: bool = False
+    gpu_default_profile: str | None = None
+    gpu_profiles: list[GpuProfile] = Field(default_factory=list, max_length=32)
     workspace_service_type: Literal["LoadBalancer", "NodePort"] = "LoadBalancer"
     workspace_service_host: str | None = None
     workspace_service_annotations: dict[str, str] = Field(default_factory=dict)
@@ -79,6 +260,7 @@ class Settings(BaseSettings):
         "kubeconfig_context",
         "cli_signing_key",
         "insights_signing_key",
+        "gpu_default_profile",
         mode="before",
     )
     @classmethod
@@ -171,7 +353,30 @@ class Settings(BaseSettings):
             raise ValueError("Insights retention must satisfy rawDays <= hourlyDays <= dailyDays")
         if self.insights_max_compressed_bytes > self.insights_max_expanded_bytes:
             raise ValueError("Insights compressed limit cannot exceed expanded limit")
+        profile_names = [profile.name for profile in self.gpu_profiles]
+        if len(profile_names) != len(set(profile_names)):
+            raise ValueError("GPU profile names must be unique")
+        if self.gpu_default_profile is not None:
+            self.gpu_default_profile = self.gpu_default_profile.strip().lower()
+            if self.gpu_default_profile not in profile_names:
+                raise ValueError("gpu_default_profile must name a configured GPU profile")
+        if self.gpu_enabled:
+            if not profile_names:
+                raise ValueError("gpu_enabled requires at least one GPU profile")
+            if self.gpu_default_profile is None:
+                raise ValueError("gpu_enabled requires gpu_default_profile")
         return self
+
+    def resolve_gpu_profile(self, requested_name: str | None) -> GpuProfile:
+        """Resolve a user request to one trusted installation profile."""
+        if not self.gpu_enabled:
+            raise ValueError("GPU acceleration is disabled by the operator")
+        profile_name = requested_name or self.gpu_default_profile
+        for profile in self.gpu_profiles:
+            if profile.name == profile_name:
+                return profile
+        available = ", ".join(profile.name for profile in self.gpu_profiles)
+        raise ValueError(f"unknown GPU profile {profile_name!r}; available profiles: {available}")
 
 
 @lru_cache

--- a/controller/src/devboxes_controller/manager.py
+++ b/controller/src/devboxes_controller/manager.py
@@ -15,12 +15,13 @@ from kubernetes.client.exceptions import ApiException
 from kubernetes.utils.quantity import parse_quantity
 
 from .auth import Authenticator
-from .config import Settings
+from .config import GpuProfile, Settings
 from .models import (
     CreateDevboxRequest,
     DeleteResult,
     Devbox,
     DevboxState,
+    GpuAllocation,
     InsightsState,
     Preset,
 )
@@ -28,6 +29,10 @@ from .resources import (
     ANNOTATION_AUTO_STOPPED_AT,
     ANNOTATION_CREATED_AT,
     ANNOTATION_EXPIRES_AT,
+    ANNOTATION_GPU_CONFIG,
+    ANNOTATION_GPU_COUNT,
+    ANNOTATION_GPU_PROFILE,
+    ANNOTATION_GPU_RESOURCE,
     ANNOTATION_INSIGHTS_STATE,
     ANNOTATION_INSIGHTS_TEMPLATE_HASH,
     ANNOTATION_INSTANCE_ID,
@@ -97,6 +102,11 @@ class DevboxManager:
         """Create compute, SSH, and persistent storage for a devbox."""
         if request.ttl_hours > self.settings.max_ttl_hours:
             raise ValueError(f"ttl_hours cannot exceed {self.settings.max_ttl_hours}")
+        gpu_profile = (
+            self.settings.resolve_gpu_profile(request.gpu.profile)
+            if request.gpu is not None
+            else None
+        )
 
         name = resource_name(request.name)
         if await self._deployment_exists(name):
@@ -157,6 +167,7 @@ class DevboxManager:
             self.settings.workspace_service_account_name,
             self.settings.workspace_priority_class,
             self.settings.image_pull_secret,
+            gpu_profile=gpu_profile,
             instance_id=instance_id,
             insights_enabled=self.settings.insights_enabled,
             insights_endpoint=self.settings.insights_controller_url,
@@ -555,6 +566,7 @@ class DevboxManager:
             ),
             repository=annotations.get(ANNOTATION_REPOSITORY),
         )
+        gpu_profile = _resolved_gpu_profile(annotations, self.settings)
         credential = self.authenticator.issue_insights_token(instance_id, name)
         secret_name = await self._ensure_insights_secret(name, instance_id, credential)
         desired = build_deployment(
@@ -565,6 +577,7 @@ class DevboxManager:
             self.settings.workspace_service_account_name,
             self.settings.workspace_priority_class,
             self.settings.image_pull_secret,
+            gpu_profile=gpu_profile,
             instance_id=instance_id,
             insights_enabled=True,
             insights_endpoint=self.settings.insights_controller_url,
@@ -645,6 +658,7 @@ class DevboxManager:
             restarts=restarts,
             storage_size=annotations.get(ANNOTATION_STORAGE, "20Gi"),
             message=message,
+            gpu=_gpu_allocation(annotations),
             instance_id=annotations.get(ANNOTATION_INSTANCE_ID),
             insights_state=_insights_state(self.settings.insights_enabled, deployment, desired),
         )
@@ -731,6 +745,20 @@ def _state(
         )
         if phase == "Failed" or failure:
             return DevboxState.DEGRADED, failure or "Pod failed"
+        scheduling_condition = next(
+            (
+                condition
+                for condition in (getattr(pod.status, "conditions", None) or [])
+                if getattr(condition, "type", None) == "PodScheduled"
+                and getattr(condition, "status", None) == "False"
+            ),
+            None,
+        )
+        if scheduling_condition is not None:
+            detail = getattr(scheduling_condition, "message", None)
+            if detail:
+                return DevboxState.STARTING, f"Scheduling blocked: {str(detail)[:320]}"
+            return DevboxState.STARTING, "Waiting for a node with the requested resources"
     if pod_ready:
         return DevboxState.STARTING, "Waiting for an SSH service address"
     return DevboxState.STARTING, "Preparing workspace and SSH"
@@ -742,6 +770,58 @@ def _valid_instance_id(value: str) -> bool:
     except ValueError:
         return False
     return parsed.version == 4 and str(parsed) == value
+
+
+def _resolved_gpu_profile(
+    annotations: dict[str, str],
+    settings: Settings,
+) -> GpuProfile | None:
+    """Recover the pinned GPU profile snapshot used by an existing workspace."""
+    raw_profile = annotations.get(ANNOTATION_GPU_CONFIG)
+    if raw_profile:
+        try:
+            return GpuProfile.model_validate_json(raw_profile)
+        except ValueError as error:
+            raise ValueError("stored GPU profile configuration is invalid") from error
+    profile_name = annotations.get(ANNOTATION_GPU_PROFILE)
+    if profile_name:
+        for profile in settings.gpu_profiles:
+            if profile.name == profile_name:
+                return profile
+        raise ValueError(
+            f"stored GPU profile {profile_name!r} is unavailable and has no resolved snapshot"
+        )
+    return None
+
+
+def _gpu_allocation(annotations: dict[str, str]) -> GpuAllocation | None:
+    """Build a stable user-facing GPU allocation from Deployment annotations."""
+    profile_name = annotations.get(ANNOTATION_GPU_PROFILE)
+    if not profile_name:
+        return None
+    raw_profile = annotations.get(ANNOTATION_GPU_CONFIG)
+    if raw_profile:
+        try:
+            profile = GpuProfile.model_validate_json(raw_profile)
+        except ValueError:
+            profile = None
+        if profile is not None:
+            return GpuAllocation(
+                profile=profile.name,
+                display_name=profile.display_name,
+                resource_name=profile.resource_name,
+                count=profile.count,
+            )
+    try:
+        count = min(64, max(1, int(annotations.get(ANNOTATION_GPU_COUNT, "1"))))
+    except ValueError:
+        count = 1
+    return GpuAllocation(
+        profile=profile_name,
+        display_name=profile_name,
+        resource_name=annotations.get(ANNOTATION_GPU_RESOURCE, "unknown"),
+        count=count,
+    )
 
 
 def _has_insights_sidecar(deployment: Any) -> bool:

--- a/controller/src/devboxes_controller/models.py
+++ b/controller/src/devboxes_controller/models.py
@@ -37,6 +37,27 @@ class InsightsState(StrEnum):
     RESTART_REQUIRED = "restart_required"
 
 
+class GpuRequest(BaseModel):
+    """Request an operator-approved GPU profile for one workspace."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    profile: str | None = Field(default=None, min_length=1, max_length=40)
+
+    @field_validator("profile")
+    @classmethod
+    def valid_profile(cls, value: str | None) -> str | None:
+        """Normalize and validate a configured GPU profile name."""
+        if value is None:
+            return None
+        value = value.strip().lower()
+        if not DEVBOX_NAME_RE.fullmatch(value):
+            raise ValueError(
+                "use 1-40 lowercase letters, digits, or hyphens; start and end alphanumeric"
+            )
+        return value
+
+
 class CreateDevboxRequest(BaseModel):
     """Validate a request to create a devbox."""
 
@@ -46,6 +67,7 @@ class CreateDevboxRequest(BaseModel):
     preset: Preset = Preset.SMALL
     ttl_hours: int = Field(default=24, ge=1, le=168)
     repository: str | None = Field(default=None, max_length=240)
+    gpu: GpuRequest | None = None
 
     @field_validator("name")
     @classmethod
@@ -70,6 +92,15 @@ class CreateDevboxRequest(BaseModel):
         return value
 
 
+class GpuAllocation(BaseModel):
+    """Describe the pinned GPU allocation attached to a devbox."""
+
+    profile: str
+    display_name: str
+    resource_name: str
+    count: int
+
+
 class Devbox(BaseModel):
     """Represent the observable state of one managed devbox."""
 
@@ -87,6 +118,7 @@ class Devbox(BaseModel):
     restarts: int = 0
     storage_size: str
     message: str | None = None
+    gpu: GpuAllocation | None = None
     instance_id: str | None = None
     insights_state: InsightsState = InsightsState.DISABLED
 
@@ -102,6 +134,31 @@ class WhoAmI(BaseModel):
 
     user: str
     mode: str
+
+
+class GpuProfileSummary(BaseModel):
+    """Expose a safe user-facing view of one configured GPU profile."""
+
+    name: str
+    display_name: str
+    description: str | None = None
+    resource_name: str
+    count: int
+    default: bool = False
+
+
+class GpuCapabilities(BaseModel):
+    """Describe the GPU feature and profiles available to API clients."""
+
+    enabled: bool
+    default_profile: str | None = None
+    profiles: list[GpuProfileSummary]
+
+
+class Capabilities(BaseModel):
+    """Describe installation capabilities that shape user workflows."""
+
+    gpu: GpuCapabilities
 
 
 class CliTokenRequest(BaseModel):

--- a/controller/src/devboxes_controller/resources.py
+++ b/controller/src/devboxes_controller/resources.py
@@ -5,6 +5,7 @@ import json
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+from .config import GpuProfile
 from .models import CreateDevboxRequest, Preset
 
 MANAGED_BY = "devboxes-controller"
@@ -20,6 +21,10 @@ ANNOTATION_AUTO_STOPPED_AT = "devboxes.bonalab.org/auto-stopped-at"
 ANNOTATION_INSTANCE_ID = "insights.devboxes.bonalab.org/instance-id"
 ANNOTATION_INSIGHTS_STATE = "insights.devboxes.bonalab.org/state"
 ANNOTATION_INSIGHTS_TEMPLATE_HASH = "insights.devboxes.bonalab.org/template-hash"
+ANNOTATION_GPU_PROFILE = "gpu.devboxes.bonalab.org/profile"
+ANNOTATION_GPU_RESOURCE = "gpu.devboxes.bonalab.org/resource"
+ANNOTATION_GPU_COUNT = "gpu.devboxes.bonalab.org/count"
+ANNOTATION_GPU_CONFIG = "gpu.devboxes.bonalab.org/resolved-config"
 
 
 PRESETS: dict[Preset, dict[str, str]] = {
@@ -64,6 +69,7 @@ def annotations(
     request: CreateDevboxRequest,
     now: datetime | None = None,
     instance_id: str | None = None,
+    gpu_profile: GpuProfile | None = None,
 ) -> dict[str, str]:
     """Return lifecycle and user-input annotations for a new devbox."""
     now = now or datetime.now(UTC)
@@ -78,6 +84,19 @@ def annotations(
         result[ANNOTATION_REPOSITORY] = request.repository
     if instance_id:
         result[ANNOTATION_INSTANCE_ID] = instance_id
+    if gpu_profile is not None:
+        result.update(
+            {
+                ANNOTATION_GPU_PROFILE: gpu_profile.name,
+                ANNOTATION_GPU_RESOURCE: gpu_profile.resource_name,
+                ANNOTATION_GPU_COUNT: str(gpu_profile.count),
+                ANNOTATION_GPU_CONFIG: json.dumps(
+                    gpu_profile.model_dump(mode="json", by_alias=True, exclude_none=True),
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ),
+            }
+        )
     return result
 
 
@@ -117,6 +136,7 @@ def build_deployment(
     workspace_service_account_name: str,
     workspace_priority_class: str | None = None,
     image_pull_secret: str | None = None,
+    gpu_profile: GpuProfile | None = None,
     now: datetime | None = None,
     instance_id: str | None = None,
     insights_enabled: bool = False,
@@ -131,12 +151,32 @@ def build_deployment(
     """Build the disposable workspace Deployment for a devbox."""
     name = resource_name(request.name)
     box_labels = labels(request.name)
+    effective_workspace_image = (
+        gpu_profile.workspace_image
+        if gpu_profile is not None and gpu_profile.workspace_image is not None
+        else workspace_image
+    )
     env = [
         {"name": "DEVBOX_NAME", "value": request.name},
         {"name": "DEVBOX_PRESET", "value": request.preset.value},
     ]
     if request.repository:
         env.append({"name": "DEVBOX_REPOSITORY", "value": request.repository})
+    if gpu_profile is not None:
+        env.extend(
+            [
+                {"name": "DEVBOX_GPU_PROFILE", "value": gpu_profile.name},
+                {"name": "DEVBOX_GPU_RESOURCE", "value": gpu_profile.resource_name},
+                {"name": "DEVBOX_GPU_COUNT", "value": str(gpu_profile.count)},
+            ]
+        )
+        if gpu_profile.supplemental_groups:
+            env.append(
+                {
+                    "name": "DEVBOX_GPU_SUPPLEMENTAL_GROUPS",
+                    "value": ",".join(str(group) for group in gpu_profile.supplemental_groups),
+                }
+            )
     if insights_enabled:
         env.extend(
             [
@@ -180,7 +220,7 @@ def build_deployment(
         "containers": [
             {
                 "name": "devbox",
-                "image": workspace_image,
+                "image": effective_workspace_image,
                 "imagePullPolicy": "IfNotPresent",
                 "ports": [{"name": "ssh", "containerPort": 2222, "protocol": "TCP"}],
                 "env": env,
@@ -255,6 +295,23 @@ def build_deployment(
         pod_spec["priorityClassName"] = workspace_priority_class
     if image_pull_secret:
         pod_spec["imagePullSecrets"] = [{"name": image_pull_secret}]
+    if gpu_profile is not None:
+        main_resources = pod_spec["containers"][0]["resources"]
+        main_resources["requests"][gpu_profile.resource_name] = gpu_profile.count
+        main_resources["limits"][gpu_profile.resource_name] = gpu_profile.count
+        if gpu_profile.runtime_class_name:
+            pod_spec["runtimeClassName"] = gpu_profile.runtime_class_name
+        if gpu_profile.supplemental_groups:
+            pod_spec["securityContext"]["supplementalGroups"] = list(
+                gpu_profile.supplemental_groups
+            )
+        if gpu_profile.node_selector:
+            pod_spec["nodeSelector"] = dict(gpu_profile.node_selector)
+        if gpu_profile.tolerations:
+            pod_spec["tolerations"] = [
+                toleration.model_dump(mode="json", by_alias=True, exclude_none=True)
+                for toleration in gpu_profile.tolerations
+            ]
 
     if insights_enabled:
         if not all((instance_id, insights_endpoint, insights_credential)):
@@ -274,6 +331,8 @@ def build_deployment(
         pod_spec["containers"].append(
             {
                 "name": "insights-agent",
+                # Keep the privacy boundary on the release workspace image. A
+                # profile image overrides only the interactive workspace.
                 "image": workspace_image,
                 "imagePullPolicy": "IfNotPresent",
                 "command": ["python3", "/usr/local/bin/devbox-insights-agent"],
@@ -315,10 +374,19 @@ def build_deployment(
             }
         )
 
-    deployment_annotations = annotations(request, now, instance_id)
+    deployment_annotations = annotations(request, now, instance_id, gpu_profile)
     deployment_annotations[ANNOTATION_INSIGHTS_STATE] = (
         "collecting" if insights_enabled else "disabled"
     )
+    template_annotations = {ANNOTATION_INSTANCE_ID: instance_id} if instance_id is not None else {}
+    if gpu_profile is not None:
+        template_annotations.update(
+            {
+                ANNOTATION_GPU_PROFILE: gpu_profile.name,
+                ANNOTATION_GPU_RESOURCE: gpu_profile.resource_name,
+                ANNOTATION_GPU_COUNT: str(gpu_profile.count),
+            }
+        )
     manifest: dict[str, Any] = {
         "apiVersion": "apps/v1",
         "kind": "Deployment",
@@ -339,9 +407,7 @@ def build_deployment(
             "template": {
                 "metadata": {
                     "labels": box_labels,
-                    "annotations": (
-                        {ANNOTATION_INSTANCE_ID: instance_id} if instance_id is not None else {}
-                    ),
+                    "annotations": template_annotations,
                 },
                 "spec": pod_spec,
             },

--- a/controller/src/devboxes_controller/static/app.js
+++ b/controller/src/devboxes_controller/static/app.js
@@ -119,6 +119,10 @@ function renderBox(box) {
   nameCell.scope = "row";
   nameCell.append(node("span", "devbox-name", box.name));
   const details = [box.preset, box.storage_size];
+  if (box.gpu) {
+    const unit = box.gpu.count === 1 ? "unit" : "units";
+    details.push(`${box.gpu.display_name} · ${box.gpu.count} ${unit}`);
+  }
   if (box.repository) {
     details.push(box.repository);
   }
@@ -265,6 +269,7 @@ elements.createForm.addEventListener("submit", async (event) => {
     preset: form.get("preset"),
     ttl_hours: Number(form.get("ttl_hours")),
     repository: form.get("repository") || null,
+    gpu: form.get("gpu_profile") ? { profile: form.get("gpu_profile") } : null,
   };
   submit.disabled = true;
   submit.setAttribute("aria-busy", "true");

--- a/controller/src/devboxes_controller/static/styles.css
+++ b/controller/src/devboxes_controller/static/styles.css
@@ -357,7 +357,7 @@ h3 {
 
 .create-form {
   display: grid;
-  grid-template-columns: minmax(9rem, 1fr) minmax(10rem, 0.9fr) minmax(9rem, 0.8fr) minmax(14rem, 1.5fr) auto;
+  grid-template-columns: minmax(9rem, 1fr) minmax(9rem, 0.8fr) minmax(9rem, 0.8fr) minmax(11rem, 1fr) minmax(14rem, 1.4fr) auto;
   align-items: end;
   gap: var(--space-3);
 }
@@ -994,6 +994,11 @@ select:focus {
   color: var(--ink);
 }
 
+.docs-article p code,
+.docs-article li code {
+  white-space: nowrap;
+}
+
 .command-block {
   margin: var(--space-5) 0;
   overflow: hidden;
@@ -1527,11 +1532,11 @@ kbd {
 
 @media (max-width: 70rem) {
   .create-form {
-    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
   .field-repository {
-    grid-column: span 2;
+    grid-column: span 3;
   }
 
   .docs-layout {
@@ -1610,6 +1615,11 @@ kbd {
     grid-column: span 2;
   }
 
+  .create-button {
+    width: 100%;
+    grid-column: span 2;
+  }
+
   .login-page {
     padding: 0;
   }
@@ -1680,6 +1690,7 @@ kbd {
 
   .create-button {
     width: 100%;
+    grid-column: auto;
   }
 
   .devbox-table,
@@ -1702,6 +1713,7 @@ kbd {
 
   .devbox-table td,
   .devbox-table tbody th,
+  .devbox-table th:first-child,
   .devbox-table td:first-child,
   .devbox-table td:last-child {
     width: 100%;

--- a/controller/src/devboxes_controller/templates/cli_authorize.html
+++ b/controller/src/devboxes_controller/templates/cli_authorize.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="color-scheme" content="light">
     <title>Authorize Devbox CLI · Devboxes</title>
-    <link rel="icon" href="/static/favicon.svg?v=0.3.0" type="image/svg+xml">
-    <link rel="stylesheet" href="/static/styles.css?v=0.3.0">
+    <link rel="icon" href="/static/favicon.svg?v=0.4.0" type="image/svg+xml">
+    <link rel="stylesheet" href="/static/styles.css?v=0.4.0">
   </head>
   <body class="login-page">
     <main class="authorization-shell" aria-labelledby="authorization-title">

--- a/controller/src/devboxes_controller/templates/docs.html
+++ b/controller/src/devboxes_controller/templates/docs.html
@@ -37,6 +37,7 @@
             <a href="#quick-start">Quick start</a>
             <a href="#lifecycle">What persists</a>
             <a href="#create">Create a box</a>
+            <a href="#gpu">GPU acceleration</a>
             <a href="#ssh-tmux">SSH and tmux</a>
             <a href="#accounts">Accounts and tools</a>
             <a href="#daily-workflow">Daily workflow</a>
@@ -221,6 +222,62 @@ devbox create nightly --preset small --no-wait</code></pre>
             <li><strong>large</strong> is for memory-heavy builds, databases, or parallel tooling.</li>
             <li>Reusing a retained volume can expand it for a larger preset; volumes are never shrunk.</li>
           </ul>
+        </section>
+
+        <section class="docs-section" id="gpu" tabindex="-1">
+          <h2>Use an operator-approved GPU</h2>
+          {% if gpu.enabled %}
+          <p>
+            This installation exposes {{ gpu.profiles | length }} GPU profile{% if gpu.profiles | length != 1 %}s{% endif %}.
+            CPU-only remains the default. In the CLI, <code>--gpu</code> selects the operator's default and
+            <code>--gpu-profile</code> selects an exact profile. The workbench offers the same catalog.
+          </p>
+
+          <div class="docs-table-wrap" tabindex="0" aria-label="Available GPU profile table; scroll horizontally if needed">
+            <table class="docs-table">
+              <thead>
+                <tr>
+                  <th scope="col">Profile</th>
+                  <th scope="col">Accelerator</th>
+                  <th scope="col">Allocation</th>
+                  <th scope="col">Purpose</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for profile in gpu.profiles %}
+                <tr>
+                  <th scope="row"><code>{{ profile.name }}</code>{% if profile.default %} · default{% endif %}</th>
+                  <td>{{ profile.display_name }}</td>
+                  <td>{{ profile.count }} x <code>{{ profile.resource_name }}</code></td>
+                  <td>{{ profile.description or "Operator-approved GPU workload" }}</td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+
+          <div class="command-block">
+            <div class="command-heading">
+              <span>Discover and request GPU profiles</span>
+              <button class="command-copy" type="button" data-copy-target="gpu-command" aria-label="Copy GPU commands">Copy</button>
+            </div>
+            <pre><code id="gpu-command">devbox gpu profiles
+devbox create inference --gpu --ssh
+devbox create training --gpu-profile {{ gpu.profiles[0].name }} --preset large --ssh</code></pre>
+          </div>
+
+          <p>
+            The selected profile is pinned to the devbox Deployment, including its resource name,
+            count, image override, runtime class, supplemental groups, node selector, and tolerations. Stop and start
+            preserve that allocation; deleting and recreating lets you choose a different profile.
+          </p>
+          {% else %}
+          <p>
+            GPU acceleration is disabled on this installation. New boxes are CPU-only. An operator
+            can enable named profiles through the Helm chart after installing a compatible device
+            driver and container runtime on GPU nodes.
+          </p>
+          {% endif %}
         </section>
 
         <section class="docs-section" id="ssh-tmux" tabindex="-1">

--- a/controller/src/devboxes_controller/templates/index.html
+++ b/controller/src/devboxes_controller/templates/index.html
@@ -54,7 +54,9 @@
             <h2 id="create-title">Create a devbox</h2>
             <p>Compute expires into a safe stopped state. Your volume is never deleted automatically.</p>
           </div>
-          <span class="capacity-note">{{ storage_class }} storage · {{ workspace_service_type }} SSH · OCI images</span>
+          <span class="capacity-note">
+            {{ storage_class }} storage · {{ workspace_service_type }} SSH{% if gpu.enabled %} · GPU profiles{% endif %}
+          </span>
         </div>
 
         <form id="create-form" class="create-form">
@@ -84,6 +86,19 @@
               {% if hours <= max_ttl_hours %}
               <option value="{{ hours }}"{% if hours == default_ttl_hours %} selected{% endif %}>{{ label }}</option>
               {% endif %}
+              {% endfor %}
+            </select>
+          </div>
+          <div class="field field-accelerator">
+            <label for="gpu-profile">Accelerator <span>optional</span></label>
+            <select id="gpu-profile" name="gpu_profile"{% if not gpu.enabled %} disabled{% endif %}>
+              <option value="">
+                {% if gpu.enabled %}CPU only{% else %}CPU only · GPU disabled{% endif %}
+              </option>
+              {% for profile in gpu.profiles %}
+              <option value="{{ profile.name }}">
+                {{ profile.display_name }} · {{ profile.count }} unit{% if profile.count != 1 %}s{% endif %}{% if profile.default %} · default{% endif %}
+              </option>
               {% endfor %}
             </select>
           </div>

--- a/controller/src/devboxes_controller/templates/login.html
+++ b/controller/src/devboxes_controller/templates/login.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="color-scheme" content="light">
     <title>Sign in · Devboxes</title>
-    <link rel="icon" href="/static/favicon.svg?v=0.3.0" type="image/svg+xml">
-    <link rel="stylesheet" href="/static/styles.css?v=0.3.0">
+    <link rel="icon" href="/static/favicon.svg?v=0.4.0" type="image/svg+xml">
+    <link rel="stylesheet" href="/static/styles.css?v=0.4.0">
   </head>
   <body class="login-page">
     <main class="login-shell">

--- a/controller/tests/fakes.py
+++ b/controller/tests/fakes.py
@@ -8,6 +8,7 @@ from devboxes_controller.models import (
     DeleteResult,
     Devbox,
     DevboxState,
+    GpuAllocation,
     Preset,
 )
 
@@ -16,6 +17,7 @@ def sample_devbox(
     name: str = "atlas",
     state: DevboxState = DevboxState.READY,
     preset: Preset = Preset.MEDIUM,
+    gpu: GpuAllocation | None = None,
 ) -> Devbox:
     now = datetime.now(UTC)
     ready = state is DevboxState.READY
@@ -41,13 +43,21 @@ def sample_devbox(
                 else "Preparing workspace and SSH"
             )
         ),
+        gpu=gpu,
     )
 
 
 class FakeManager:
     def __init__(self) -> None:
         self.boxes = [
-            sample_devbox(),
+            sample_devbox(
+                gpu=GpuAllocation(
+                    profile="nvidia-l4",
+                    display_name="NVIDIA L4",
+                    resource_name="nvidia.com/gpu",
+                    count=1,
+                )
+            ),
             sample_devbox("paperclip", DevboxState.STOPPED, Preset.SMALL),
             sample_devbox("nightly", DevboxState.STARTING, Preset.LARGE),
         ]
@@ -69,6 +79,18 @@ class FakeManager:
             raise DevboxConflictError(f"devbox {request.name!r} already exists")
         box = sample_devbox(request.name, DevboxState.STARTING, request.preset)
         box.repository = request.repository
+        if request.gpu is not None:
+            profile = request.gpu.profile or "nvidia-l4"
+            display_name, resource_name = {
+                "nvidia-l4": ("NVIDIA L4", "nvidia.com/gpu"),
+                "nvidia-shared": ("NVIDIA shared", "nvidia.com/gpu.shared"),
+            }.get(profile, (profile, "nvidia.com/gpu"))
+            box.gpu = GpuAllocation(
+                profile=profile,
+                display_name=display_name,
+                resource_name=resource_name,
+                count=1,
+            )
         box.ssh_host = None
         box.ssh_command = None
         box.pod_ready = False

--- a/controller/tests/preview_app.py
+++ b/controller/tests/preview_app.py
@@ -1,5 +1,5 @@
 from devboxes_controller.app import create_app
-from devboxes_controller.config import Settings
+from devboxes_controller.config import GpuProfile, Settings
 
 from .fakes import FakeManager
 
@@ -7,5 +7,23 @@ settings = Settings(
     access_token="preview-access-token-at-least-32-characters",
     cookie_secure=False,
     cleanup_interval_seconds=3600,
+    gpu_enabled=True,
+    gpu_default_profile="nvidia-l4",
+    gpu_profiles=[
+        GpuProfile(
+            name="nvidia-l4",
+            displayName="NVIDIA L4",
+            description="One dedicated GPU for inference and CUDA development",
+            resourceName="nvidia.com/gpu",
+            count=1,
+        ),
+        GpuProfile(
+            name="nvidia-shared",
+            displayName="NVIDIA shared",
+            description="One time-sliced GPU allocation for interactive experiments",
+            resourceName="nvidia.com/gpu.shared",
+            count=1,
+        ),
+    ],
 )
 app = create_app(settings, FakeManager())  # type: ignore[arg-type]

--- a/controller/tests/test_app.py
+++ b/controller/tests/test_app.py
@@ -4,13 +4,13 @@ from fastapi.testclient import TestClient
 
 from devboxes_controller.app import create_app
 from devboxes_controller.auth import pkce_s256
-from devboxes_controller.config import Settings
+from devboxes_controller.config import GpuProfile, Settings
 
 from .fakes import FakeManager
 
 
-def app_client() -> TestClient:
-    settings = Settings(
+def app_client(settings: Settings | None = None) -> TestClient:
+    settings = settings or Settings(
         access_token="test-access-token-at-least-32-characters",
         cookie_secure=False,
         cleanup_interval_seconds=3600,
@@ -192,6 +192,74 @@ def test_api_maps_conflicts_and_missing_names() -> None:
 def test_api_requires_authentication() -> None:
     with app_client() as client:
         assert client.get("/api/v1/devboxes").status_code == 401
+        assert client.get("/api/v1/capabilities").status_code == 401
+
+
+def test_gpu_capabilities_expose_only_safe_profile_metadata() -> None:
+    settings = Settings(
+        access_token="test-access-token-at-least-32-characters",
+        cookie_secure=False,
+        cleanup_interval_seconds=3600,
+        gpu_enabled=True,
+        gpu_default_profile="nvidia-l4",
+        gpu_profiles=[
+            GpuProfile(
+                name="nvidia-l4",
+                displayName="NVIDIA L4",
+                description="One dedicated inference GPU",
+                resourceName="nvidia.com/gpu",
+                count=1,
+                workspaceImage="private.example/devboxes-cuda:12.8",
+                runtimeClassName="nvidia",
+                supplementalGroups=[44],
+            )
+        ],
+    )
+    headers = {"Authorization": "Bearer test-access-token-at-least-32-characters"}
+
+    with app_client(settings) as client:
+        response = client.get("/api/v1/capabilities", headers=headers)
+        created = client.post(
+            "/api/v1/devboxes",
+            headers=headers,
+            json={"name": "inference", "gpu": {"profile": "nvidia-l4"}},
+        )
+        browser_login(client)
+        dashboard = client.get("/")
+        documentation = client.get("/docs")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "gpu": {
+            "enabled": True,
+            "default_profile": "nvidia-l4",
+            "profiles": [
+                {
+                    "name": "nvidia-l4",
+                    "display_name": "NVIDIA L4",
+                    "description": "One dedicated inference GPU",
+                    "resource_name": "nvidia.com/gpu",
+                    "count": 1,
+                    "default": True,
+                }
+            ],
+        }
+    }
+    assert "workspaceImage" not in response.text
+    assert "runtimeClassName" not in response.text
+    assert "supplementalGroups" not in response.text
+    assert created.status_code == 201
+    assert created.json()["gpu"] == {
+        "profile": "nvidia-l4",
+        "display_name": "NVIDIA L4",
+        "resource_name": "nvidia.com/gpu",
+        "count": 1,
+    }
+    assert '<option value="nvidia-l4">' in dashboard.text
+    assert "NVIDIA L4 · 1 unit · default" in dashboard.text
+    assert "GPU profiles" in dashboard.text
+    assert "Use an operator-approved GPU" in documentation.text
+    assert "devbox create inference --gpu --ssh" in documentation.text
 
 
 def test_api_rejects_invalid_path_names_before_kubernetes() -> None:

--- a/controller/tests/test_app.py
+++ b/controller/tests/test_app.py
@@ -79,7 +79,7 @@ def test_browser_login_and_dashboard_session() -> None:
         assert dashboard.headers["x-content-type-options"] == "nosniff"
         assert "Kubernetes connected" in dashboard.text
         assert "cluster default storage" in dashboard.text
-        styles = client.get("/static/styles.css?v=0.3.0")
+        styles = client.get("/static/styles.css?v=0.4.0")
         assert "[hidden]" in styles.text
         assert "display: none !important" in styles.text
         payload = client.get("/api/v1/devboxes").json()

--- a/controller/tests/test_config.py
+++ b/controller/tests/test_config.py
@@ -1,7 +1,9 @@
+import json
+
 import pytest
 from pydantic import ValidationError
 
-from devboxes_controller.config import Settings
+from devboxes_controller.config import GpuProfile, GpuToleration, Settings
 
 
 def test_access_token_is_required() -> None:
@@ -57,3 +59,148 @@ def test_cli_signing_key_is_optional_but_strong_when_configured() -> None:
             cli_signing_key="too-short",
             _env_file=None,
         )
+
+
+def test_gpu_profiles_are_disabled_by_default_and_resolve_explicitly() -> None:
+    profile = GpuProfile(
+        name="nvidia-l4",
+        displayName="NVIDIA L4",
+        resourceName="nvidia.com/gpu",
+        count=1,
+        runtimeClassName="nvidia",
+        tolerations=[GpuToleration(key="nvidia.com/gpu", operator="Exists", effect="NoSchedule")],
+    )
+    settings = Settings(
+        access_token="test-access-token-at-least-32-characters",
+        gpu_enabled=True,
+        gpu_default_profile="nvidia-l4",
+        gpu_profiles=[profile],
+        _env_file=None,
+    )
+
+    assert settings.resolve_gpu_profile(None) is profile
+    assert settings.resolve_gpu_profile("nvidia-l4") is profile
+    with pytest.raises(ValueError, match="unknown GPU profile 'amd-rocm'"):
+        settings.resolve_gpu_profile("amd-rocm")
+
+
+def test_enabled_gpu_configuration_requires_a_valid_unique_default() -> None:
+    profile = GpuProfile(
+        name="nvidia-l4",
+        displayName="NVIDIA L4",
+        resourceName="nvidia.com/gpu",
+        count=1,
+    )
+
+    with pytest.raises(ValidationError, match="gpu_default_profile"):
+        Settings(
+            access_token="test-access-token-at-least-32-characters",
+            gpu_enabled=True,
+            gpu_profiles=[profile],
+            _env_file=None,
+        )
+
+    with pytest.raises(ValidationError, match="unique"):
+        Settings(
+            access_token="test-access-token-at-least-32-characters",
+            gpu_default_profile="nvidia-l4",
+            gpu_profiles=[profile, profile],
+            _env_file=None,
+        )
+
+
+def test_gpu_configuration_bounds_the_profile_catalog() -> None:
+    profiles = [
+        GpuProfile(
+            name=f"gpu-{index}",
+            displayName=f"GPU {index}",
+            resourceName="example.com/gpu",
+            count=1,
+        )
+        for index in range(33)
+    ]
+
+    with pytest.raises(ValidationError, match="at most 32 items"):
+        Settings(
+            access_token="test-access-token-at-least-32-characters",
+            gpu_profiles=profiles,
+            _env_file=None,
+        )
+
+
+def test_gpu_profile_rejects_unqualified_resources_and_ambiguous_tolerations() -> None:
+    with pytest.raises(ValidationError, match="vendor-qualified"):
+        GpuProfile(
+            name="invalid",
+            displayName="Invalid",
+            resourceName="gpu",
+            count=1,
+        )
+
+    with pytest.raises(ValidationError, match="cannot set a value"):
+        GpuToleration(
+            key="nvidia.com/gpu",
+            operator="Exists",
+            value="present",
+        )
+
+
+def test_gpu_profile_rejects_invalid_kubernetes_names() -> None:
+    with pytest.raises(ValidationError, match="vendor-qualified"):
+        GpuProfile(
+            name="invalid",
+            displayName="Invalid",
+            resourceName="nvidia..com/gpu",
+            count=1,
+        )
+
+    with pytest.raises(ValidationError, match="DNS subdomain"):
+        GpuProfile(
+            name="invalid",
+            displayName="Invalid",
+            resourceName="nvidia.com/gpu",
+            count=1,
+            runtimeClassName=f"{'x' * 64}.example",
+        )
+
+    with pytest.raises(ValidationError, match="container image reference"):
+        GpuProfile(
+            name="invalid",
+            displayName="Invalid",
+            resourceName="nvidia.com/gpu",
+            count=1,
+            workspaceImage="https://registry.example/workspace:cuda latest",
+        )
+
+    with pytest.raises(ValidationError, match="duplicate group IDs"):
+        GpuProfile(
+            name="invalid",
+            displayName="Invalid",
+            resourceName="amd.com/gpu",
+            count=1,
+            supplementalGroups=[44, 44],
+        )
+
+
+def test_gpu_profiles_load_from_the_helm_json_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DEVBOXES_ACCESS_TOKEN", "test-access-token-at-least-32-characters")
+    monkeypatch.setenv("DEVBOXES_GPU_ENABLED", "true")
+    monkeypatch.setenv("DEVBOXES_GPU_DEFAULT_PROFILE", "nvidia-l4")
+    monkeypatch.setenv(
+        "DEVBOXES_GPU_PROFILES",
+        json.dumps(
+            [
+                {
+                    "name": "nvidia-l4",
+                    "displayName": "NVIDIA L4",
+                    "description": "  Dedicated inference  ",
+                    "resourceName": "nvidia.com/gpu",
+                    "count": 1,
+                }
+            ]
+        ),
+    )
+
+    settings = Settings(_env_file=None)
+
+    assert settings.resolve_gpu_profile(None).description == "Dedicated inference"

--- a/controller/tests/test_insights_app.py
+++ b/controller/tests/test_insights_app.py
@@ -31,6 +31,14 @@ def enabled_app(tmp_path: Path) -> tuple[TestClient, Settings]:
 
 
 def otlp_batch(batch_id: str = "a" * 64) -> bytes:
+    payload = json.loads((FIXTURES / "claude-2.1.205-otlp.json").read_text())
+    observed_ns = str(int(datetime.now(UTC).timestamp() * 1_000_000_000))
+    for resource_metrics in payload["resourceMetrics"]:
+        for scope_metrics in resource_metrics["scopeMetrics"]:
+            for metric in scope_metrics["metrics"]:
+                for data_point in metric.get("sum", {}).get("dataPoints", []):
+                    data_point["startTimeUnixNano"] = observed_ns
+                    data_point["timeUnixNano"] = observed_ns
     return json.dumps(
         {
             "schema_version": 1,
@@ -38,7 +46,7 @@ def otlp_batch(batch_id: str = "a" * 64) -> bytes:
             "sent_at": datetime.now(UTC).isoformat(),
             "collector": "otel",
             "kind": "otlp",
-            "payload": json.loads((FIXTURES / "claude-2.1.205-otlp.json").read_text()),
+            "payload": payload,
         }
     ).encode()
 
@@ -76,10 +84,11 @@ def test_authenticated_ingest_drives_summary_series_export_and_purge(tmp_path: P
         "Content-Encoding": "gzip",
     }
     api_headers = {"Authorization": f"Bearer {MASTER_TOKEN}"}
+    batch = gzip.compress(otlp_batch())
     with client:
         accepted = client.post(
             "/internal/v1/insights/batches",
-            content=gzip.compress(otlp_batch()),
+            content=batch,
             headers=ingest_headers,
         )
         assert accepted.status_code == 200
@@ -87,7 +96,7 @@ def test_authenticated_ingest_drives_summary_series_export_and_purge(tmp_path: P
 
         duplicate = client.post(
             "/internal/v1/insights/batches",
-            content=gzip.compress(otlp_batch()),
+            content=batch,
             headers=ingest_headers,
         )
         assert duplicate.json()["duplicate"] is True

--- a/controller/tests/test_manager.py
+++ b/controller/tests/test_manager.py
@@ -6,19 +6,23 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 from kubernetes.client.exceptions import ApiException
 
-from devboxes_controller.config import Settings
+from devboxes_controller.config import GpuProfile, Settings
 from devboxes_controller.manager import (
     DevboxConflictError,
     DevboxManager,
     DevboxNotFoundError,
+    _gpu_allocation,
+    _resolved_gpu_profile,
     _service_endpoint,
     _state,
     _ttl_hours,
 )
-from devboxes_controller.models import CreateDevboxRequest, DevboxState, Preset
+from devboxes_controller.models import CreateDevboxRequest, DevboxState, GpuRequest, Preset
 from devboxes_controller.resources import (
     ANNOTATION_CREATED_AT,
     ANNOTATION_EXPIRES_AT,
+    ANNOTATION_GPU_CONFIG,
+    ANNOTATION_GPU_PROFILE,
     ANNOTATION_INSIGHTS_STATE,
     ANNOTATION_INSTANCE_ID,
     ANNOTATION_PRESET,
@@ -175,6 +179,27 @@ def test_state_reports_readiness_and_known_failures() -> None:
     )
 
 
+def test_state_surfaces_scheduler_capacity_failures() -> None:
+    pending_pod = SimpleNamespace(
+        status=SimpleNamespace(
+            phase="Pending",
+            conditions=[
+                SimpleNamespace(
+                    type="PodScheduled",
+                    status="False",
+                    message="0/3 nodes are available: 3 Insufficient nvidia.com/gpu.",
+                )
+            ],
+            container_statuses=[],
+        )
+    )
+
+    assert _state(1, pending_pod, False, None) == (
+        DevboxState.STARTING,
+        "Scheduling blocked: 0/3 nodes are available: 3 Insufficient nvidia.com/gpu.",
+    )
+
+
 def test_start_renews_the_original_ttl_atomically() -> None:
     apps = Mock()
     apps.read_namespaced_deployment.return_value = SimpleNamespace(
@@ -299,6 +324,57 @@ def test_create_uses_portable_node_port_and_default_storage_configuration() -> N
     assert "nodePort" not in service["spec"]["ports"][0]
 
 
+def test_create_resolves_the_default_gpu_profile_before_kubernetes_writes() -> None:
+    apps = Mock()
+    apps.read_namespaced_deployment.side_effect = ApiException(status=404)
+    core = Mock()
+    core.read_namespaced_persistent_volume_claim.side_effect = ApiException(status=404)
+    profile = GpuProfile(
+        name="nvidia-l4",
+        displayName="NVIDIA L4",
+        resourceName="nvidia.com/gpu",
+        count=1,
+    )
+    manager = DevboxManager(
+        Settings(
+            access_token="test-access-token-at-least-32-characters",
+            gpu_enabled=True,
+            gpu_default_profile="nvidia-l4",
+            gpu_profiles=[profile],
+        ),
+        apps_api=apps,
+        core_api=core,
+    )
+    manager.get = AsyncMock(return_value=Mock())  # type: ignore[method-assign]
+
+    asyncio.run(manager.create(CreateDevboxRequest(name="atlas", gpu=GpuRequest())))
+
+    deployment = apps.create_namespaced_deployment.call_args.args[1]
+    assert deployment["metadata"]["annotations"][ANNOTATION_GPU_PROFILE] == "nvidia-l4"
+    assert (
+        deployment["spec"]["template"]["spec"]["containers"][0]["resources"]["limits"][
+            "nvidia.com/gpu"
+        ]
+        == 1
+    )
+
+
+def test_create_rejects_gpu_requests_when_the_feature_is_disabled() -> None:
+    apps = Mock()
+    core = Mock()
+    manager = DevboxManager(
+        Settings(access_token="test-access-token-at-least-32-characters"),
+        apps_api=apps,
+        core_api=core,
+    )
+
+    with pytest.raises(ValueError, match="disabled by the operator"):
+        asyncio.run(manager.create(CreateDevboxRequest(name="atlas", gpu=GpuRequest())))
+
+    apps.read_namespaced_deployment.assert_not_called()
+    core.create_namespaced_persistent_volume_claim.assert_not_called()
+
+
 def _legacy_deployment(replicas: int) -> SimpleNamespace:
     now = datetime.now(UTC)
     return SimpleNamespace(
@@ -321,6 +397,29 @@ def _legacy_deployment(replicas: int) -> SimpleNamespace:
             ),
         ),
     )
+
+
+def test_resolved_gpu_profile_snapshot_survives_later_operator_changes() -> None:
+    profile = GpuProfile(
+        name="nvidia-l4",
+        displayName="NVIDIA L4",
+        resourceName="nvidia.com/gpu",
+        count=1,
+        runtimeClassName="nvidia",
+    )
+    annotations = {
+        ANNOTATION_GPU_PROFILE: profile.name,
+        ANNOTATION_GPU_CONFIG: profile.model_dump_json(by_alias=True, exclude_none=True),
+    }
+    settings = Settings(access_token="test-access-token-at-least-32-characters")
+
+    assert _resolved_gpu_profile(annotations, settings) == profile
+    assert _gpu_allocation(annotations).model_dump() == {
+        "profile": "nvidia-l4",
+        "display_name": "NVIDIA L4",
+        "resource_name": "nvidia.com/gpu",
+        "count": 1,
+    }
 
 
 def test_insights_create_scopes_identity_to_the_retained_home_volume() -> None:
@@ -412,6 +511,60 @@ def test_stopped_legacy_workspace_template_is_reconciled_without_starting_it() -
     containers = patch["spec"]["template"]["spec"]["containers"]
     assert [item["name"] for item in containers] == ["devbox", "insights-agent"]
     assert patch["metadata"]["annotations"][ANNOTATION_INSIGHTS_STATE] == "collecting"
+
+
+def test_insights_reconciliation_uses_the_pinned_gpu_snapshot() -> None:
+    profile = GpuProfile(
+        name="amd-rocm",
+        displayName="AMD ROCm GPU",
+        resourceName="amd.com/gpu",
+        count=1,
+        workspaceImage="registry.example/devboxes-rocm:6.4",
+        runtimeClassName="gpu-runtime",
+        supplementalGroups=[44, 109],
+    )
+    deployment = _legacy_deployment(0)
+    deployment.metadata.annotations.update(
+        {
+            ANNOTATION_GPU_PROFILE: profile.name,
+            ANNOTATION_GPU_CONFIG: profile.model_dump_json(
+                by_alias=True,
+                exclude_none=True,
+            ),
+        }
+    )
+    apps = Mock()
+    apps.list_namespaced_deployment.return_value = SimpleNamespace(items=[deployment])
+    apps.read_namespaced_deployment.return_value = _legacy_deployment(0)
+    core = Mock()
+    core.read_namespaced_persistent_volume_claim.return_value = SimpleNamespace(
+        metadata=SimpleNamespace(
+            annotations={ANNOTATION_INSTANCE_ID: "99999999-9999-4999-8999-999999999999"}
+        )
+    )
+    manager = DevboxManager(
+        Settings(
+            access_token="test-access-token-at-least-32-characters",
+            insights_enabled=True,
+        ),
+        apps_api=apps,
+        core_api=core,
+    )
+
+    assert asyncio.run(manager.reconcile_insights()) == ["atlas"]
+
+    patch = apps.patch_namespaced_deployment.call_args.args[2]
+    pod = patch["spec"]["template"]["spec"]
+    main, sidecar = pod["containers"]
+    main_environment = {item["name"]: item["value"] for item in main["env"]}
+    assert main["image"] == "registry.example/devboxes-rocm:6.4"
+    assert main["resources"]["requests"]["amd.com/gpu"] == 1
+    assert main["resources"]["limits"]["amd.com/gpu"] == 1
+    assert main_environment["DEVBOX_GPU_SUPPLEMENTAL_GROUPS"] == "44,109"
+    assert pod["runtimeClassName"] == "gpu-runtime"
+    assert pod["securityContext"]["supplementalGroups"] == [44, 109]
+    assert sidecar["image"] == manager.settings.workspace_image
+    assert "amd.com/gpu" not in sidecar["resources"]["requests"]
 
 
 def test_node_port_model_includes_allocated_port_in_ssh_command() -> None:

--- a/controller/tests/test_models.py
+++ b/controller/tests/test_models.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
-from devboxes_controller.models import CreateDevboxRequest, Preset
+from devboxes_controller.models import CreateDevboxRequest, GpuRequest, Preset
 
 
 def test_create_request_normalizes_name_and_repository() -> None:
@@ -24,3 +24,18 @@ def test_create_request_rejects_invalid_names(name: str) -> None:
 def test_create_request_rejects_arbitrary_clone_urls() -> None:
     with pytest.raises(ValidationError):
         CreateDevboxRequest(name="atlas", repository="ssh://untrusted.example/repository")
+
+
+def test_gpu_request_supports_default_and_named_operator_profiles() -> None:
+    assert CreateDevboxRequest(name="atlas", gpu={}).gpu == GpuRequest()
+    request = CreateDevboxRequest(name="atlas", gpu={"profile": " NVIDIA-L4 "})
+
+    assert request.gpu == GpuRequest(profile="nvidia-l4")
+
+
+def test_gpu_request_rejects_raw_kubernetes_configuration() -> None:
+    with pytest.raises(ValidationError):
+        CreateDevboxRequest(
+            name="atlas",
+            gpu={"profile": "nvidia", "resource_name": "nvidia.com/gpu"},
+        )

--- a/controller/tests/test_resources.py
+++ b/controller/tests/test_resources.py
@@ -2,8 +2,13 @@ from datetime import UTC, datetime
 
 import pytest
 
+from devboxes_controller.config import GpuProfile, GpuToleration
 from devboxes_controller.models import CreateDevboxRequest, Preset
 from devboxes_controller.resources import (
+    ANNOTATION_GPU_CONFIG,
+    ANNOTATION_GPU_COUNT,
+    ANNOTATION_GPU_PROFILE,
+    ANNOTATION_GPU_RESOURCE,
     ANNOTATION_INSTANCE_ID,
     ANNOTATION_TTL_HOURS,
     build_deployment,
@@ -140,3 +145,56 @@ def test_enabled_insights_requires_a_complete_scoped_configuration() -> None:
             "devboxes-workspace",
             insights_enabled=True,
         )
+
+
+def test_gpu_profile_is_applied_only_to_the_workspace_container() -> None:
+    instance_id = "99999999-9999-4999-8999-999999999999"
+    profile = GpuProfile(
+        name="nvidia-l4",
+        displayName="NVIDIA L4",
+        description="One dedicated inference GPU",
+        resourceName="nvidia.com/gpu",
+        count=1,
+        workspaceImage="registry.example/devboxes-cuda:12.8",
+        runtimeClassName="nvidia",
+        supplementalGroups=[44, 109],
+        nodeSelector={"accelerator": "nvidia"},
+        tolerations=[GpuToleration(key="nvidia.com/gpu", operator="Exists", effect="NoSchedule")],
+    )
+    deployment = build_deployment(
+        request(),
+        "devboxes",
+        "ghcr.io/vicotrbb/devboxes-workspace:test",
+        "devboxes-workspace",
+        "devboxes-workspace",
+        gpu_profile=profile,
+        instance_id=instance_id,
+        insights_enabled=True,
+        insights_endpoint="http://devboxes:8000",
+        insights_credential=f"v1.{instance_id}.atlas.{'a' * 43}",
+    )
+    annotations = deployment["metadata"]["annotations"]
+    pod = deployment["spec"]["template"]["spec"]
+    container = pod["containers"][0]
+    environment = {item["name"]: item["value"] for item in container["env"]}
+
+    assert annotations[ANNOTATION_GPU_PROFILE] == "nvidia-l4"
+    assert annotations[ANNOTATION_GPU_RESOURCE] == "nvidia.com/gpu"
+    assert annotations[ANNOTATION_GPU_COUNT] == "1"
+    assert '"runtimeClassName":"nvidia"' in annotations[ANNOTATION_GPU_CONFIG]
+    assert container["image"] == "registry.example/devboxes-cuda:12.8"
+    assert container["resources"]["requests"]["nvidia.com/gpu"] == 1
+    assert container["resources"]["limits"]["nvidia.com/gpu"] == 1
+    assert environment["DEVBOX_GPU_PROFILE"] == "nvidia-l4"
+    assert environment["DEVBOX_GPU_RESOURCE"] == "nvidia.com/gpu"
+    assert environment["DEVBOX_GPU_COUNT"] == "1"
+    assert environment["DEVBOX_GPU_SUPPLEMENTAL_GROUPS"] == "44,109"
+    assert pod["runtimeClassName"] == "nvidia"
+    assert pod["securityContext"]["supplementalGroups"] == [44, 109]
+    assert pod["nodeSelector"] == {"accelerator": "nvidia"}
+    assert pod["tolerations"] == [
+        {"key": "nvidia.com/gpu", "operator": "Exists", "effect": "NoSchedule"}
+    ]
+    assert "nvidia.com/gpu" not in pod["containers"][1]["resources"]["requests"]
+    assert "nvidia.com/gpu" not in pod["containers"][1]["resources"]["limits"]
+    assert pod["containers"][1]["image"] == "ghcr.io/vicotrbb/devboxes-workspace:test"

--- a/controller/uv.lock
+++ b/controller/uv.lock
@@ -382,7 +382,7 @@ wheels = [
 
 [[package]]
 name = "devboxes-controller"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/docs/api.md
+++ b/docs/api.md
@@ -29,6 +29,7 @@ The shared token controls every devbox in the installation, including permanent 
 | `POST` | `/auth/cli/authorize` | 303 | Approve or deny a CSRF-protected CLI request |
 | `POST` | `/api/v1/auth/cli/token` | 200 | Exchange a one-time code and PKCE verifier |
 | `GET` | `/api/v1/whoami` | 200 | Verify authentication and identity |
+| `GET` | `/api/v1/capabilities` | 200 | Discover installation GPU profiles |
 | `GET` | `/api/v1/devboxes` | 200 | List managed devboxes |
 | `POST` | `/api/v1/devboxes` | 201 | Create a devbox |
 | `GET` | `/api/v1/devboxes/{name}` | 200 | Read one devbox |
@@ -50,6 +51,31 @@ loopback redirect ending in `/callback`, a high-entropy state, a PKCE challenge,
 browser subject for about two minutes. The token endpoint accepts JSON fields
 `grant_type`, `code`, `code_verifier`, `client_id`, and `redirect_uri`. Errors are generic,
 responses are `no-store`, codes are single-use, and no refresh token is returned.
+
+## Installation capabilities
+
+Authenticated clients use `GET /api/v1/capabilities` to discover optional installation features. GPU capability discovery returns only the safe user contract, not profile images, RuntimeClasses, supplemental groups, selectors, or tolerations:
+
+```json
+{
+  "gpu": {
+    "enabled": true,
+    "default_profile": "nvidia-l4",
+    "profiles": [
+      {
+        "name": "nvidia-l4",
+        "display_name": "NVIDIA L4",
+        "description": "One dedicated L4 for inference",
+        "resource_name": "nvidia.com/gpu",
+        "count": 1,
+        "default": true
+      }
+    ]
+  }
+}
+```
+
+When GPU support is disabled, `enabled` is false, `default_profile` is null, and `profiles` is empty. Clients should treat new top-level capabilities as additive.
 
 ## Create a devbox
 
@@ -75,8 +101,23 @@ Request fields:
 | `preset` | string | `small`, `medium`, or `large`, default `small` |
 | `ttl_hours` | integer | 1 to the configured maximum, default 24 |
 | `repository` | string or null | `owner/repository` or an HTTPS GitHub repository URL |
+| `gpu` | object or null | Optional GPU request; omit or use null for CPU-only |
+| `gpu.profile` | string or null | Configured profile name; null selects the operator default |
 
 Unknown fields are rejected. Creating an existing name returns `409 Conflict`. Recreating a deleted name reuses its retained PVC, and expands it when the new preset requests more storage.
+
+Request the operator's default GPU profile with an empty nested object:
+
+```json
+{
+  "name": "inference",
+  "preset": "medium",
+  "ttl_hours": 24,
+  "gpu": {}
+}
+```
+
+Select an exact profile with `"gpu": {"profile": "nvidia-l4"}`. The controller rejects GPU requests while the feature is disabled and rejects unknown profile names before creating any Kubernetes resource. Clients cannot send resource names, counts, images, RuntimeClasses, supplemental groups, selectors, or tolerations. Read [GPU acceleration](gpu.md) for the operator contract.
 
 ## Devbox response
 
@@ -95,7 +136,21 @@ Unknown fields are rejected. Creating an existing name returns `409 Conflict`. R
   "pod_ready": true,
   "restarts": 0,
   "storage_size": "30Gi",
-  "message": null
+  "message": null,
+  "gpu": null
+}
+```
+
+GPU boxes return their resolved allocation:
+
+```json
+{
+  "gpu": {
+    "profile": "nvidia-l4",
+    "display_name": "NVIDIA L4",
+    "resource_name": "nvidia.com/gpu",
+    "count": 1
+  }
 }
 ```
 
@@ -106,7 +161,7 @@ States are:
 - `stopped`, the Deployment has zero replicas and the home volume remains.
 - `degraded`, the pod failed or a known image or restart failure is visible.
 
-Timestamps are RFC 3339 values. `ssh_host`, `ssh_command`, `pod_name`, and `message` can be null while resources converge.
+Timestamps are RFC 3339 values. `ssh_host`, `ssh_command`, `pod_name`, and `message` can be null while resources converge. `gpu` is null for CPU-only boxes and remains stable across stop and start.
 
 ## Lifecycle semantics
 
@@ -160,7 +215,7 @@ Validation failures contain a list of structured errors. Common status codes are
 | 403 | Missing or invalid browser CSRF token |
 | 404 | Devbox does not exist |
 | 409 | Devbox name already exists |
-| 422 | Invalid path, request field, repository, preset, or TTL |
+| 422 | Invalid path, request field, repository, preset, TTL, disabled GPU feature, or unknown GPU profile |
 | 503 | Controller cannot reach the Kubernetes API through `/ready` |
 
 Clients should preserve the status code, treat error payload text as diagnostic rather than stable machine data, and retry only transient transport or readiness failures.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,7 +29,32 @@ The controller translates lifecycle operations into native Kubernetes resources 
 - One `PersistentVolumeClaim` per devbox, mounted at `/home/dev`.
 - When Insights is enabled, one scoped ingest `Secret` per devbox and one central Insights `PersistentVolumeClaim` for the controller.
 
-Resource names are deterministic (`devbox-NAME`), and labels plus annotations carry controller ownership, creation time, expiry, preset, repository, and retained storage size.
+Resource names are deterministic (`devbox-NAME`), and labels plus annotations carry controller ownership, creation time, expiry, preset, repository, retained storage size, and any resolved GPU allocation.
+
+## GPU resolution path
+
+GPU acceleration adds an operator-owned policy layer without changing resource ownership:
+
+```text
+Helm GPU profiles
+       |
+       v
+validated controller settings
+       |
+       +---- authenticated capability catalog ----> CLI and dashboard
+       |
+user selects profile name
+       |
+       v
+resolved pinned snapshot
+       |
+       v
+Deployment pod template ----> scheduler ----> device plugin or DRA-bridged resource
+```
+
+The create API accepts only an optional profile name. The controller resolves that name before any Kubernetes write, then applies the trusted image override, RuntimeClass, supplemental groups, node selector, tolerations, and extended resource count. It writes the extended resource to both requests and limits on the main container. Insights and other sidecars do not receive GPU resources. The Insights sidecar also remains on the installation's release workspace image, preserving its pinned privacy sanitizer when the interactive container uses a specialized GPU image.
+
+The resolved profile is stored as a bounded Deployment annotation. Existing boxes therefore retain their allocation across stop, start, TTL expiry, and template reconciliation even if the Helm catalog later changes. Capability discovery publishes only profile names, labels, descriptions, resources, and counts. Scheduling details and images remain operator policy.
 
 ## Persistence model
 
@@ -53,6 +78,7 @@ The workspace entrypoint refuses to start without `SSH_AUTHORIZED_KEYS`. It prep
 
 - Controller RBAC is a Role scoped to the release namespace; it cannot manage cluster-wide resources.
 - Workspace service accounts have no RBAC binding and do not mount Kubernetes API tokens.
+- GPU clients can choose only a configured profile name. They cannot inject images, device resources, RuntimeClasses, supplemental groups, selectors, tolerations, privileged mode, host paths, or device paths.
 - Workspace Secrets are mounted read-only with mode `0440`, scoped to the workspace group, and are not embedded in either image.
 - Each Insights ingest credential is HMAC-signed, write-only, scoped to one box and UUID instance, and stored in a dedicated namespaced Secret. It is never a controller, browser, or CLI credential.
 - The controller runs as a non-root user with a read-only root filesystem and all Linux capabilities dropped.
@@ -78,6 +104,10 @@ Presets specify requests and memory limits while intentionally leaving CPU burst
 | large | 2 | 4Gi | 16Gi | 50Gi |
 
 A retained PVC is expanded when a larger preset is requested, subject to the StorageClass supporting expansion. PVCs are never shrunk.
+
+GPU profiles add one vendor-qualified extended resource with the same integer value in requests and limits. Kubernetes extended resources are not overcommitted unless the installed device plugin intentionally advertises shared units. Optional selectors and tolerations direct boxes to operator-prepared GPU pools; an optional RuntimeClass activates a non-default vendor runtime.
+
+The controller does not guess capacity or reserve a device before creation. Kubernetes scheduling is the source of truth. A box stays `starting` when capacity or constraints cannot be satisfied, and the controller exposes the `PodScheduled=False` reason to the CLI and dashboard. Device plugins remain responsible for allocation and device injection.
 
 ## Availability
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -103,14 +103,36 @@ devbox create atlas --preset medium --ttl 24 --repo owner/project --ssh
 | `--preset small\|medium\|large` | Resource and storage preset, default `small` |
 | `--ttl HOURS` | Auto-stop interval from 1 to 168 hours, default 24 |
 | `--repo OWNER/REPOSITORY` | Clone a GitHub repository on first boot |
+| `--gpu` | Request the operator's default GPU profile |
+| `--gpu-profile PROFILE` | Request an exact operator-approved profile; implies `--gpu` |
 | `--no-wait` | Return after the API accepts the request |
 | `--ssh` | Wait for readiness, then connect |
 
 `--ssh` takes precedence over `--no-wait` because an SSH connection requires readiness.
 
+GPU creation remains opt-in:
+
+```bash
+devbox create inference --gpu --ssh
+devbox create training --gpu-profile nvidia-l4 --preset large --ssh
+```
+
+The controller rejects a GPU request when the feature is disabled or the profile is unknown. If Kubernetes cannot schedule the requested resource before the wait timeout, the error includes the latest scheduler reason. Use `--no-wait` for intentionally queued work and inspect it with `devbox status`.
+
+### `devbox gpu profiles`
+
+Discover the profiles available for new boxes:
+
+```bash
+devbox gpu profiles
+devbox gpu profiles --json
+```
+
+`devbox gpu` is a shorthand for the same catalog. Human output shows the profile identifier, display name, resource count, Kubernetes resource name, description, and default marker. JSON returns `enabled`, `default_profile`, and `profiles`. When the operator disables GPU support, the command reports that state instead of presenting stale profiles.
+
 ### `devbox list`
 
-List boxes sorted by creation time, newest first.
+List boxes sorted by creation time, newest first. Human output includes an `ACCELERATOR` column containing `cpu` or the resolved GPU profile.
 
 ```bash
 devbox list
@@ -119,7 +141,7 @@ devbox list --json
 
 ### `devbox status NAME`
 
-Show state, preset, storage, expiry, repository, SSH address, and any readiness message.
+Show state, preset, storage, accelerator allocation, expiry, repository, SSH address, and any readiness or scheduling message.
 
 ```bash
 devbox status atlas
@@ -214,7 +236,7 @@ JSON preserves nullable measurements and response metadata. CSV prefixes spreads
 
 ## Output and scripting
 
-Human-readable results go to stdout. Progress and connection-wait messages go to stderr. Failures return a nonzero exit status. `--json` emits formatted JSON for list, status, create, start, stop, and metrics workflows, which can be consumed with `jq`:
+Human-readable results go to stdout. Progress and connection-wait messages go to stderr. Failures return a nonzero exit status. `--json` emits formatted JSON for list, status, create, start, stop, GPU capability, and metrics workflows, which can be consumed with `jq`:
 
 ```bash
 devbox list --json | jq -r '.[] | select(.state == "ready") | .name'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,9 +3,9 @@
 Use a values file for durable installations:
 
 ```bash
-helm show values oci://ghcr.io/vicotrbb/charts/devboxes --version 0.3.0 > values.yaml
+helm show values oci://ghcr.io/vicotrbb/charts/devboxes --version 0.4.0 > values.yaml
 helm upgrade --install devboxes oci://ghcr.io/vicotrbb/charts/devboxes \
-  --version 0.3.0 \
+  --version 0.4.0 \
   --namespace devboxes \
   --create-namespace \
   --values values.yaml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,6 +56,75 @@ master token in derived mode, or rotating the dedicated key, revokes all issued 
 
 The namespace must permit the workspace pod's documented `sudo` capability set. Kubernetes Pod Security `baseline` is compatible; `restricted` is not.
 
+## GPU acceleration
+
+GPU acceleration is disabled by default. Operators configure one or more named profiles and choose a default profile for `devbox create --gpu`. CPU-only creation remains available regardless of whether GPU support is enabled.
+
+| Value | Default | Meaning |
+| --- | --- | --- |
+| `gpu.enabled` | `false` | Publish configured profiles and accept GPU requests |
+| `gpu.defaultProfile` | empty | Profile selected by CLI `--gpu`; required when enabled |
+| `gpu.profiles[].name` | none | Stable lowercase identifier exposed to clients |
+| `gpu.profiles[].displayName` | none | Human-readable accelerator name |
+| `gpu.profiles[].description` | empty | Short workload or service-level description |
+| `gpu.profiles[].resourceName` | none | Vendor-qualified Kubernetes extended resource |
+| `gpu.profiles[].count` | none | Integer resource units requested and limited |
+| `gpu.profiles[].workspaceImage` | empty | Optional complete GPU-capable Devboxes workspace image |
+| `gpu.profiles[].runtimeClassName` | empty | Optional existing RuntimeClass selected for the pod |
+| `gpu.profiles[].supplementalGroups` | `[]` | Up to eight non-root device group IDs required by the node runtime |
+| `gpu.profiles[].nodeSelector` | `{}` | Optional operator-owned GPU node labels |
+| `gpu.profiles[].tolerations` | `[]` | Optional taint tolerations limited to standard fields |
+
+Example NVIDIA profile:
+
+```yaml
+gpu:
+  enabled: true
+  defaultProfile: nvidia-l4
+  profiles:
+    - name: nvidia-l4
+      displayName: NVIDIA L4
+      description: One dedicated L4 for inference and CUDA development
+      resourceName: nvidia.com/gpu
+      count: 1
+      workspaceImage: ghcr.io/example/devboxes-workspace-cuda:12.8
+      runtimeClassName: nvidia
+      nodeSelector:
+        accelerator: nvidia-l4
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+```
+
+Example AMD profile:
+
+```yaml
+gpu:
+  enabled: true
+  defaultProfile: amd-rocm
+  profiles:
+    - name: amd-rocm
+      displayName: AMD ROCm GPU
+      description: One GPU for ROCm development
+      resourceName: amd.com/gpu
+      count: 1
+      workspaceImage: ghcr.io/example/devboxes-workspace-rocm:6.4
+      supplementalGroups: [44, 109]
+      nodeSelector:
+        accelerator: amd-rocm
+```
+
+The AMD group IDs are examples only. Use the actual `video`, `render`, or vendor device groups required by your node image and runtime. Omit `supplementalGroups` when device permissions already work for the `dev` user. Group zero is rejected.
+
+The pod receives each configured group and the workspace entrypoint adds `dev` to the matching image group, creating a `devbox-device-ID` group when the numeric ID is otherwise unnamed. This ensures OpenSSH sessions retain access after initializing the login user's groups.
+
+`workspaceImage` must preserve the complete interactive Devboxes workspace contract, including the entrypoint, `dev` user, SSH setup, persistent home layout, and runtime secret mount. Derive it from the matching released workspace image and add only the workload's pinned user-space GPU libraries. The Insights sidecar retains the installation's release workspace image, so a profile override cannot replace its privacy sanitizer. A host driver, device plugin, and container runtime remain cluster prerequisites.
+
+The chart rejects unknown fields, duplicate profiles, invalid Kubernetes names, unsafe toleration combinations, missing defaults, more than 32 profiles, and enabled configurations with no profiles. The controller repeats semantic validation at startup. Clients can select only a profile name; they cannot override the trusted scheduling or image policy.
+
+The resolved profile is stored with each Deployment. Changing or removing a Helm profile affects only later creations. Stop and start retain the original allocation. Delete and recreate the box to select a new profile. See [GPU acceleration](gpu.md) for the full model and operational guidance.
+
 ## SSH service
 
 For clusters with load-balancer support:

--- a/docs/development.md
+++ b/docs/development.md
@@ -49,7 +49,7 @@ Set `DEVBOX_CONFIG` to a temporary path during development to avoid changing you
 
 The server-rendered UI lives under `controller/src/devboxes_controller/templates`, with plain CSS and JavaScript under `static`. Preserve WCAG 2.2 AA contrast, complete keyboard operation, visible focus, textual status, responsive layouts, and reduced-motion support. Keep inline scripts and handlers out of templates so the Content Security Policy remains strict.
 
-The test fake can preview all lifecycle states without a Kubernetes cluster:
+The test fake can preview all lifecycle states and multiple GPU profiles without a Kubernetes cluster:
 
 ```bash
 cd controller
@@ -88,6 +88,8 @@ kind create cluster --name devboxes
 ```
 
 The CI Kind job builds both images and the CLI, loads the images into a clean cluster, creates placeholder Secrets, and installs the local chart with Insights enabled. It exercises the authenticated API, SSH, scoped ingest Secret, provider-shaped OTLP batches, batch deduplication, Git baseline and activity, durable outbox during controller downtime, central database persistence, retained identity, CLI output and exports, explicit Insights purge, workspace recreation, host identity, and final PVC purge.
+
+GPU coverage is intentionally layered because ordinary Kind workers do not expose production accelerator hardware. Controller tests prove disabled and named-profile API behavior, exact pod resources and scheduling fields, scheduler diagnostics, allocation reporting, and pinned profile reconciliation. CLI tests prove command parsing and request shape. `scripts/test-helm-gpu.sh` proves disabled, enabled, and invalid chart contracts. The clean-cluster test enables an intentionally unschedulable extended resource and proves capability discovery, CLI and API selection, the generated pod contract, Pending diagnostics, and complete cleanup. A real GPU cluster remains the acceptance environment for vendor driver, runtime, image, and workload compatibility.
 
 Privacy tests use fixtures derived from exact Codex and Claude Code clients pinned in the workspace image. Fixtures must use synthetic values. Never commit a real prompt, response, command, path, repository name, email address, provider credential, account identifier, or session identifier. The agent and controller sanitizers are separate trust boundaries and both require regression coverage.
 

--- a/docs/golden-path.md
+++ b/docs/golden-path.md
@@ -13,6 +13,8 @@ Provide one reliable SSH exposure path:
 
 Keep `externalTrafficPolicy: Cluster` for the portable default. Use `Local` only after confirming that the load balancer health checks and routing send traffic to the node hosting the devbox pod. `Local` can remove an extra node hop, but incorrect health routing makes SSH unavailable.
 
+For GPU workloads, first install and verify the vendor driver, device plugin or Dynamic Resource Allocation driver with a compatible extended-resource bridge, and container runtime outside Devboxes. Confirm the intended extended resource appears in node allocatable capacity. Label and taint GPU pools deliberately, then encode those choices in named Devboxes profiles. Follow [GPU acceleration](gpu.md) before enabling the feature.
+
 ## 2. Use a pinned release and durable values
 
 Store installation values in version control without secrets. Pin the chart version and image tags by installing one release version as a unit.
@@ -58,6 +60,8 @@ Workspace creation uses `imagePullPolicy: IfNotPresent`. The first devbox schedu
 
 Do not depend on a cache existing on only one node. Kubernetes may schedule the next workspace elsewhere. Keep registry credentials valid even when images are pre-pulled.
 
+GPU profiles may select a larger derived workspace image. Pre-pull each configured GPU image only on nodes eligible for that profile, and validate host driver compatibility before making the profile the default.
+
 ## 4. Install and verify the CLI
 
 Use the checksummed release installer, authenticate over HTTPS, and verify the identity returned by the controller.
@@ -89,6 +93,15 @@ The command waits for the pod, OpenSSH, and the Service address, then connects t
 
 Choose `small` for light editing and administrative work. Choose `large` for memory-heavy builds, multiple language servers, or local inference. If a process is OOM-killed or the pod is evicted under memory pressure, move to a larger preset. A retained PVC expands when a larger preset is used, but it never shrinks.
 
+When GPU profiles are enabled, discover them before creating an accelerated box:
+
+```bash
+devbox gpu profiles
+devbox create inference --gpu --preset medium --ssh
+```
+
+CPU and memory presets remain independent from accelerator selection. Start with the smallest preset that satisfies host-side preprocessing and compilation, then measure before increasing it.
+
 ## 6. Tune in the right order
 
 Measure before changing the cluster. Startup and interactive performance usually improve in this order:
@@ -98,6 +111,8 @@ Measure before changing the cluster. Startup and interactive performance usually
 3. Enough allocatable CPU and memory to satisfy the preset request without contention.
 4. A direct, healthy SSH network path from the client to the workspace Service.
 5. A larger preset when the workload, rather than the platform, is resource-bound.
+
+For a GPU box, also verify advertised device capacity, profile selectors, taints, RuntimeClass availability, and the derived workspace image. A valid profile can remain queued when all matching devices are allocated; the scheduler reason appears in `devbox status`.
 
 Use these checks for a slow or pending box:
 

--- a/docs/golden-path.md
+++ b/docs/golden-path.md
@@ -47,7 +47,7 @@ kubectl create namespace devboxes
 # Create devboxes-auth and devboxes-workspace here, as described below.
 
 helm upgrade --install devboxes oci://ghcr.io/vicotrbb/charts/devboxes \
-  --version 0.3.0 \
+  --version 0.4.0 \
   --namespace devboxes \
   --values values.yaml
 ```

--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -1,0 +1,200 @@
+# GPU acceleration
+
+Devboxes supports optional GPU workloads through operator-approved profiles. A profile is a stable product contract that maps one name to a Kubernetes extended resource and the scheduling policy needed to reach it. Users choose a profile; they never supply arbitrary pod fields.
+
+CPU-only creation remains the default. Enabling GPU support does not change existing boxes or ordinary CPU workloads.
+
+## Why profiles are the API
+
+GPU clusters vary across vendors, runtimes, node pools, partitioning modes, and sharing policies. Exposing raw Kubernetes fields through the CLI would couple users to those details and would create an unsafe image and scheduling injection surface. Named profiles keep the user workflow stable while operators retain control over:
+
+- the vendor-qualified resource and integer count;
+- an optional complete GPU-capable workspace image;
+- an optional RuntimeClass;
+- up to eight optional non-root device group IDs;
+- bounded node selectors and tolerations;
+- the meaning of dedicated, partitioned, or shared capacity.
+
+The same profile catalog is returned by the authenticated API, printed by the CLI, and rendered in the dashboard. The API intentionally omits the image, RuntimeClass, supplemental groups, selectors, and tolerations from capability discovery.
+
+## Cluster prerequisites
+
+Before enabling a profile, verify all of the following:
+
+1. GPU nodes are healthy and schedulable.
+2. The vendor driver is installed on each matching node.
+3. A device plugin, GPU Operator, or Dynamic Resource Allocation driver with a compatible bridge advertises the intended extended resource in node capacity.
+4. The container runtime is configured for the vendor. Set `runtimeClassName` only when the runtime is not already the node default.
+5. The workspace image contains user-space libraries compatible with the host driver and preserves the Devboxes workspace contract.
+6. Any GPU taint has a matching profile toleration, and every profile selector matches at least one GPU node.
+
+Inspect advertised resources before changing Helm values:
+
+```bash
+kubectl get nodes -o custom-columns='NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu'
+kubectl describe node GPU_NODE_NAME
+kubectl get runtimeclass
+```
+
+For AMD or another vendor, replace the resource column with the exact resource advertised by that installation. Devboxes does not install cluster-wide drivers, device plugins, RuntimeClasses, or node labels because those are infrastructure responsibilities and usually require cluster-wide privileges.
+
+## Configure profiles with Helm
+
+Use a durable values file. This dedicated NVIDIA example assumes the cluster advertises `nvidia.com/gpu`, has an existing `nvidia` RuntimeClass, and labels L4 nodes with `accelerator=nvidia-l4`:
+
+```yaml
+gpu:
+  enabled: true
+  defaultProfile: nvidia-l4
+  profiles:
+    - name: nvidia-l4
+      displayName: NVIDIA L4
+      description: One dedicated L4 for inference and CUDA development
+      resourceName: nvidia.com/gpu
+      count: 1
+      workspaceImage: ghcr.io/example/devboxes-workspace-cuda:12.8
+      runtimeClassName: nvidia
+      nodeSelector:
+        accelerator: nvidia-l4
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+```
+
+An AMD installation commonly advertises `amd.com/gpu`:
+
+```yaml
+gpu:
+  enabled: true
+  defaultProfile: amd-rocm
+  profiles:
+    - name: amd-rocm
+      displayName: AMD ROCm GPU
+      description: One GPU for ROCm development
+      resourceName: amd.com/gpu
+      count: 1
+      workspaceImage: ghcr.io/example/devboxes-workspace-rocm:6.4
+      supplementalGroups: [44, 109]
+      nodeSelector:
+        accelerator: amd-rocm
+```
+
+The AMD group IDs are illustrative. Use the numeric groups that own the relevant device nodes on your node image, commonly the local `video` or `render` groups. Intel and some AMD configurations need this for non-root device access. Omit the field when the runtime already grants the `dev` user access. Devboxes rejects group zero, duplicate IDs, and more than eight entries.
+
+For every configured ID, Kubernetes adds the group to the pod security context and the Devboxes entrypoint adds the `dev` account to the matching image group, creating a deterministic `devbox-device-ID` group when needed. This second step is required because OpenSSH initializes the login user's groups from the image account database. A derived GPU image must preserve the Devboxes entrypoint for this behavior.
+
+Profile names use 1 to 40 lowercase letters, digits, and hyphens. Resource names must be vendor-qualified. Counts are integers from 1 through 64. The chart supports at most 32 profiles and 16 selectors or tolerations per profile. Helm schema validation and controller startup validation both fail closed.
+
+Apply the configuration and inspect the published catalog:
+
+```bash
+helm upgrade --install devboxes ./charts/devboxes \
+  --namespace devboxes \
+  --values values.yaml
+
+devbox gpu profiles
+devbox gpu profiles --json
+```
+
+The command above uses the chart in a source checkout. For a published release, use the OCI chart and pin the matching release with `--version` as described in [configuration](configuration.md).
+
+## Build a compatible workspace image
+
+The profile image is the complete workspace image, not an init container or library layer. Start from the Devboxes workspace image matching the controller and chart version, then install the minimum pinned user-space toolkit required by the workloads. Preserve:
+
+- `/usr/local/bin/devbox-entrypoint` and the default entrypoint;
+- the `dev` user and `/home/dev` persistent layout;
+- OpenSSH, tmux, sudo, and the documented readiness behavior;
+- support for the chart's runtime secret mount.
+
+Do not bake credentials into the image. Do not install a host kernel driver in the workspace image. Host drivers belong on GPU nodes; the image contains compatible user-space libraries and application tooling.
+
+When Insights is enabled, its sidecar continues to use the installation's release workspace image rather than the GPU profile override. This keeps the privacy sanitizer on the operator-pinned release artifact and prevents a specialized workload image from replacing it. Only the interactive `devbox` container uses `workspaceImage` and receives the accelerator.
+
+Validate the derived image in a non-production profile before publishing it. At minimum, prove normal SSH readiness, persistent home reuse, and the vendor diagnostic expected for your stack, such as `nvidia-smi` or `rocminfo`.
+
+## Use GPU boxes
+
+Request the operator's default profile:
+
+```bash
+devbox create inference --gpu --preset medium --ssh
+```
+
+Request an exact profile:
+
+```bash
+devbox create training --gpu-profile nvidia-l4 --preset large --ssh
+```
+
+The dashboard accelerator selector provides the same choices. CPU only is always explicit and remains the initial selection.
+
+Inspect the resolved allocation:
+
+```bash
+devbox list
+devbox status inference
+devbox status inference --json
+```
+
+The controller places the extended resource in both `requests` and `limits` on the main workspace container. Kubernetes therefore treats it as non-overcommittable capacity unless the installed vendor plugin intentionally publishes shared units. Sidecars do not receive the GPU resource.
+
+## Dedicated, partitioned, and shared devices
+
+Devboxes does not reinterpret vendor capacity. It requests the exact extended resource and count declared by the profile:
+
+- A dedicated profile usually requests one `nvidia.com/gpu`, `amd.com/gpu`, or another vendor resource from an exclusively allocated device plugin.
+- An NVIDIA MIG profile can request a resource such as `nvidia.com/mig-1g.10gb` when the installed plugin advertises it.
+- A time-sliced or virtual-GPU profile can request the shared units advertised by the installed plugin.
+- On newer clusters, a Dynamic Resource Allocation driver can participate when it exposes a compatible extended-resource bridge. The Devboxes user contract remains the profile name.
+
+Name and describe shared profiles honestly, for example `nvidia-l4-shared`, so users do not infer exclusive hardware. The profile count means advertised resource units, not necessarily physical boards. Isolation, memory guarantees, and oversubscription behavior come from the vendor driver and plugin configuration.
+
+## Lifecycle and configuration changes
+
+At creation time, the controller resolves the selected profile and stores a bounded, pinned snapshot with the Deployment. That snapshot includes the resource, count, image override, RuntimeClass, supplemental groups, selectors, and tolerations.
+
+- Stop and TTL expiry scale the same Deployment to zero, release live device capacity, and retain its GPU contract.
+- Start restores the same pod template and renews the TTL. Kubernetes may assign a different physical device that satisfies the same profile.
+- Enabling Insights on an existing box rebuilds from the stored snapshot rather than current Helm defaults.
+- Editing, renaming, or removing a Helm profile affects only later creations.
+- Delete and recreate a box to select a different profile. The retained home volume remains unless explicitly purged.
+
+This prevents an operator configuration change from silently moving a stopped box to different hardware or dropping its GPU request.
+
+## Scheduling and failure behavior
+
+Creation is asynchronous. The controller validates policy and creates Kubernetes resources, while the scheduler remains the authority on live capacity. A valid request can remain `starting` when no matching device is free.
+
+`devbox status` and the dashboard surface the scheduler's `PodScheduled=False` message. The CLI also includes the latest scheduling reason if its readiness wait expires. Common causes include insufficient extended resources, a selector that matches no node, an unhandled taint, or a missing RuntimeClass.
+
+Do not work around a Pending box by removing the GPU limit, using privileged mode, or mounting host device paths manually. Correct the driver, advertised capacity, profile, or cluster capacity. See [troubleshooting](troubleshooting.md#a-gpu-box-remains-starting) for a bounded diagnosis sequence.
+
+## Security model
+
+A GPU device expands what trusted workspace code can exercise on its assigned node. The workspace user has passwordless sudo and can use every device granted to the container, so GPU profiles belong only in the existing trusted single-operator deployment model.
+
+The GPU feature does not add privileged mode, host PID or network access, hostPath mounts, Kubernetes API credentials, or extra Linux capabilities. Clients cannot choose an image, resource name, RuntimeClass, supplemental group, selector, toleration, or device count. Only an operator changing Helm values can modify those fields.
+
+Treat every profile image and vendor runtime as part of the trusted software supply chain. Pin image tags or digests in durable values, scan derived images, track driver and toolkit compatibility, and roll changes through a test profile before making them the default.
+
+## Disable or retire a profile
+
+Set `gpu.enabled=false` to reject new GPU requests and hide the catalog. Existing GPU Deployments retain their stored specification and can still start. This fail-safe avoids destroying or mutating operator data during a configuration rollback.
+
+To retire one profile:
+
+1. Change the default to another configured profile.
+2. Remove the retired profile from Helm values.
+3. Identify existing allocations with `devbox list --json`.
+4. Ask owners to delete and recreate those boxes when migration is appropriate.
+
+Removing a profile does not reclaim a running device or rewrite existing Deployments.
+
+## Further reading
+
+- [Kubernetes scheduling GPUs](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/)
+- [Kubernetes device plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
+- [NVIDIA Kubernetes device plugin](https://github.com/NVIDIA/k8s-device-plugin)
+- [AMD GPU device plugin](https://instinct.docs.amd.com/projects/k8s-device-plugin/en/latest/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ Devboxes turns Kubernetes capacity into persistent, SSH-accessible development e
 
 - [CLI reference](cli.md), commands, global flags, environment variables, output, and SSH forwarding.
 - [API reference](api.md), authentication, endpoints, request and response contracts, and errors.
+- [GPU acceleration](gpu.md), profile design, cluster prerequisites, images, scheduling, security, and diagnosis.
 - [Insights](insights.md), opt-in AI telemetry, aggregate Git activity, privacy boundaries, retention, backup, and purge.
 - The authenticated `/docs` page in a running controller, an operator-focused guide rendered with installation-specific values.
 
@@ -32,4 +33,4 @@ Devboxes turns Kubernetes capacity into persistent, SSH-accessible development e
 
 ## Supported scope
 
-Devboxes supports one trusted operator or trusted operator group per installation. The controller is namespaced, each workspace has persistent home storage, and each SSH Service uses either `LoadBalancer` or `NodePort`. Multi-tenant authorization, untrusted workload isolation, browser terminals, and automatic PVC deletion are outside the current scope.
+Devboxes supports one trusted operator or trusted operator group per installation. The controller is namespaced, each workspace has persistent home storage, each SSH Service uses either `LoadBalancer` or `NodePort`, and GPU devices are optional operator-owned profiles. Multi-tenant authorization, untrusted workload isolation, browser terminals, cluster-wide GPU driver installation, and automatic PVC deletion are outside the current scope.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -38,6 +38,10 @@ Stopped boxes consume PVC capacity but no workspace CPU or memory. Include retai
 
 Use node selectors, affinity, tolerations, and an existing PriorityClass only when the cluster scheduling policy requires them. A priority class can improve scheduling under pressure, but it can also preempt lower-priority workloads.
 
+For GPU capacity, count the extended-resource units requested by active profile allocations and interpret them according to the vendor plugin's dedicated, partitioned, or sharing mode. `count: 1` means one advertised unit, which is not always one physical board. Monitor allocatable resources and Pending events on every GPU pool. Keep CPU-only headroom because GPU workspaces still request the selected CPU and memory preset.
+
+Profile selectors and tolerations are policy, not capacity detection. Before publishing a profile, prove that at least one node matches all selectors, tolerates the intended taints, advertises the exact resource, and can pull the profile image. Document whether each profile is dedicated or shared.
+
 ## Backups and restore
 
 The home PVC is the durable state. Back up important PVCs with a CSI snapshot system or storage-provider backup that is compatible with the active StorageClass.
@@ -82,6 +86,8 @@ helm upgrade devboxes oci://ghcr.io/vicotrbb/charts/devboxes \
 
 Then run `scripts/verify-install.sh`, confirm `/ready`, list existing boxes, create a disposable smoke box, connect over SSH, stop it, start it, and delete it with purge.
 
+When GPU configuration or images change, render the profile JSON before applying, run `devbox gpu profiles` after rollout, and create a disposable box for every changed profile. Verify the vendor diagnostic inside the box, stop and start it, and confirm the same profile contract remains. Stopping releases live device capacity, so Kubernetes may select a different physical device on start. Existing GPU Deployments retain their resolved snapshots; a Helm profile edit affects only later creations. Plan migrations as explicit delete and recreate operations, with a separate PVC retention decision.
+
 Enabling Insights does not force-restart an active legacy workspace. `devbox metrics status` reports `restart_required` until the box goes through a normal stop and start. Stopped workspaces are updated without starting compute. Confirm the expected state before and after the rollout.
 
 Prefer a reviewed values file over `--reuse-values`. It makes removed defaults and configuration drift visible.
@@ -96,6 +102,8 @@ helm rollback devboxes REVISION -n devboxes --wait
 ```
 
 A Helm rollback changes controller resources, not the contents of workspace PVCs. Do not roll back across an explicitly incompatible data or resource migration without following that release's instructions.
+
+Disabling GPU support or rolling back the catalog rejects new GPU requests but does not rewrite existing GPU Deployments. This is intentional. Inventory allocations with `devbox list --json` before retiring drivers, runtimes, images, or node pools that those boxes still require.
 
 ## Token rotation
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -81,6 +81,40 @@ kubectl get secret devboxes-workspace -n devboxes \
 
 If the pod is Ready but the box still starts, inspect the Service next.
 
+## A GPU box remains starting
+
+Start with the user-visible allocation and scheduler message:
+
+```bash
+devbox status atlas
+devbox gpu profiles
+kubectl describe pod -n devboxes \
+  -l devboxes.bonalab.org/name=atlas
+```
+
+Then verify each layer in order:
+
+1. The profile's exact extended resource appears under `status.allocatable` on at least one node.
+2. At least one node matches every profile selector.
+3. The profile tolerates every blocking taint on that node.
+4. The configured RuntimeClass exists, or the vendor runtime is already the node default when the profile omits it.
+5. Enough resource units are free. Device-plugin sharing or partitioning semantics match the profile description.
+6. The profile workspace image pulls successfully and is compatible with the node driver.
+
+Useful cluster checks include:
+
+```bash
+kubectl get nodes -o custom-columns='NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu'
+kubectl get runtimeclass
+kubectl get events -n devboxes --sort-by=.lastTimestamp
+kubectl get deployment devbox-atlas -n devboxes \
+  -o jsonpath='{.spec.template.spec.containers[0].resources}{"\n"}'
+```
+
+Replace `nvidia.com/gpu` with the profile's resource. `Insufficient RESOURCE` means Kubernetes has no free advertised units that also satisfy the pod constraints. `didn't match Pod's node affinity/selector` points to labels. Untolerated taint messages point to profile policy. A missing RuntimeClass is reported during pod admission.
+
+Do not patch the generated Deployment or add privileged mode and host device mounts. The controller owns that resource, and manual changes make the box non-reproducible. Correct the driver, capacity, or Helm profile, then delete and recreate a disposable test box. Existing boxes intentionally retain their creation-time profile snapshot.
+
 ## SSH address remains pending
 
 For `LoadBalancer`, inspect `.status.loadBalancer.ingress` and the load-balancer controller events:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "devboxes-repository-tooling",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "devboxes-repository-tooling",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "devDependencies": {
         "@eslint/js": "10.0.1",
         "eslint": "10.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devboxes-repository-tooling",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "description": "JavaScript and documentation quality gates for Devboxes",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@ set -eu
 
 release="${DEVBOXES_RELEASE:-devboxes}"
 namespace="${DEVBOXES_NAMESPACE:-devboxes}"
-version="${DEVBOXES_VERSION:-0.3.0}"
+version="${DEVBOXES_VERSION:-0.4.0}"
 repository="${DEVBOXES_CHART_REPOSITORY:-oci://ghcr.io/vicotrbb/charts/devboxes}"
 chart_source="${DEVBOXES_CHART_SOURCE:-auto}"
 controller_secret="${DEVBOXES_CONTROLLER_SECRET:-devboxes-auth}"

--- a/scripts/kind-e2e.sh
+++ b/scripts/kind-e2e.sh
@@ -327,6 +327,14 @@ else
     --set workspace.image.tag=e2e \
     --set insights.enabled=true \
     --set insights.agent.scanIntervalSeconds=15 \
+    --set gpu.enabled=true \
+    --set gpu.defaultProfile=test-gpu \
+    --set 'gpu.profiles[0].name=test-gpu' \
+    --set-string 'gpu.profiles[0].displayName=Test GPU' \
+    --set-string 'gpu.profiles[0].description=Unschedulable E2E accelerator' \
+    --set-string 'gpu.profiles[0].resourceName=example.com/gpu' \
+    --set 'gpu.profiles[0].count=1' \
+    --set 'gpu.profiles[0].supplementalGroups[0]=44' \
     --set workspace.sshService.type=NodePort \
     --set workspace.sshService.host=dev-node.example.test
 fi
@@ -347,6 +355,63 @@ test "$preserved_github_token" = preserved-runtime-test-value
 
 start_controller_port_forward
 api "http://127.0.0.1:$controller_port/api/v1/whoami" >/dev/null
+if [[ -z "$published_version" ]]; then
+  gpu_capabilities="$(api "http://127.0.0.1:$controller_port/api/v1/capabilities")"
+  jq -e '
+    .gpu.enabled == true
+    and .gpu.default_profile == "test-gpu"
+    and .gpu.profiles == [{
+      "name": "test-gpu",
+      "display_name": "Test GPU",
+      "description": "Unschedulable E2E accelerator",
+      "resource_name": "example.com/gpu",
+      "count": 1,
+      "default": true
+    }]
+  ' <<<"$gpu_capabilities" >/dev/null
+  if [[ -n "$released_cli" ]]; then
+    cli --json gpu profiles \
+      | jq -e '.enabled == true and .default_profile == "test-gpu"' >/dev/null
+    cli --json create gpu-smoke --gpu --no-wait \
+      | jq -e '.gpu.profile == "test-gpu" and .gpu.resource_name == "example.com/gpu"' \
+        >/dev/null
+  else
+    api \
+      -H 'Content-Type: application/json' \
+      -d '{"name":"gpu-smoke","gpu":{}}' \
+      "http://127.0.0.1:$controller_port/api/v1/devboxes" \
+      | jq -e '.gpu.profile == "test-gpu" and .gpu.resource_name == "example.com/gpu"' \
+        >/dev/null
+  fi
+  gpu_deployment="$(kubectl -n "$namespace" get deployment devbox-gpu-smoke -o json)"
+  jq -e '
+    .metadata.annotations["gpu.devboxes.bonalab.org/profile"] == "test-gpu"
+    and .spec.template.spec.securityContext.supplementalGroups == [44]
+    and .spec.template.spec.containers[0].resources.requests["example.com/gpu"] == "1"
+    and .spec.template.spec.containers[0].resources.limits["example.com/gpu"] == "1"
+    and ([
+      .spec.template.spec.containers[0].env[]
+      | select(.name == "DEVBOX_GPU_SUPPLEMENTAL_GROUPS")
+      | .value
+    ] == ["44"])
+    and ([.spec.template.spec.containers[1:][]?.resources.requests["example.com/gpu"]]
+      | all(. == null))
+  ' <<<"$gpu_deployment" >/dev/null
+  gpu_message=""
+  for _ in {1..30}; do
+    gpu_message="$(
+      api "http://127.0.0.1:$controller_port/api/v1/devboxes/gpu-smoke" \
+        | jq -r '.message // ""'
+    )"
+    [[ "$gpu_message" == *"example.com/gpu"* ]] && break
+    sleep 1
+  done
+  [[ "$gpu_message" == *"example.com/gpu"* ]]
+  api -X DELETE \
+    "http://127.0.0.1:$controller_port/api/v1/devboxes/gpu-smoke?purge=true" >/dev/null
+  kubectl -n "$namespace" wait --for=delete deployment/devbox-gpu-smoke --timeout=2m
+  kubectl -n "$namespace" wait --for=delete pvc/devbox-gpu-smoke-home --timeout=2m
+fi
 if [[ -n "$released_cli" ]]; then
   cli --json list | jq -e 'type == "array"' >/dev/null
 

--- a/scripts/test-helm-gpu.sh
+++ b/scripts/test-helm-gpu.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+project_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+chart="$project_directory/charts/devboxes"
+temporary_directory="$(mktemp -d)"
+trap 'rm -rf "$temporary_directory"' EXIT
+
+helm lint "$chart" --strict
+
+helm template devboxes "$chart" --namespace devboxes \
+  >"$temporary_directory/disabled.yaml"
+grep -Fq 'name: DEVBOXES_GPU_ENABLED' "$temporary_directory/disabled.yaml"
+grep -Fq 'value: "false"' "$temporary_directory/disabled.yaml"
+grep -Fq 'name: DEVBOXES_GPU_PROFILES' "$temporary_directory/disabled.yaml"
+
+gpu_profile=(
+  --set gpu.enabled=true
+  --set gpu.defaultProfile=nvidia-l4
+  --set 'gpu.profiles[0].name=nvidia-l4'
+  --set 'gpu.profiles[0].displayName=NVIDIA L4'
+  --set 'gpu.profiles[0].description=One dedicated NVIDIA L4 GPU'
+  --set-string 'gpu.profiles[0].resourceName=nvidia.com/gpu'
+  --set 'gpu.profiles[0].count=1'
+  --set-string 'gpu.profiles[0].workspaceImage=registry.example/devboxes-cuda:12.8'
+  --set 'gpu.profiles[0].runtimeClassName=nvidia'
+  --set 'gpu.profiles[0].supplementalGroups[0]=44'
+  --set 'gpu.profiles[0].nodeSelector.accelerator=nvidia'
+  --set-string 'gpu.profiles[0].tolerations[0].key=nvidia.com/gpu'
+  --set 'gpu.profiles[0].tolerations[0].operator=Exists'
+  --set 'gpu.profiles[0].tolerations[0].effect=NoSchedule'
+)
+
+helm template devboxes "$chart" --namespace devboxes "${gpu_profile[@]}" \
+  >"$temporary_directory/enabled.yaml"
+grep -Fq 'name: DEVBOXES_GPU_DEFAULT_PROFILE' "$temporary_directory/enabled.yaml"
+grep -Fq 'value: "nvidia-l4"' "$temporary_directory/enabled.yaml"
+grep -Fq 'name: DEVBOXES_GPU_PROFILES' "$temporary_directory/enabled.yaml"
+grep -Fq 'nvidia.com/gpu' "$temporary_directory/enabled.yaml"
+grep -Fq 'registry.example/devboxes-cuda:12.8' "$temporary_directory/enabled.yaml"
+grep -Fq 'supplementalGroups' "$temporary_directory/enabled.yaml"
+
+if helm template devboxes "$chart" --namespace devboxes \
+  --set gpu.enabled=true \
+  >"$temporary_directory/missing-default.yaml" \
+  2>"$temporary_directory/missing-default.err"; then
+  printf 'error: GPU render accepted an enabled feature without a default profile\n' >&2
+  exit 1
+fi
+grep -Fq 'defaultProfile' "$temporary_directory/missing-default.err"
+
+if helm template devboxes "$chart" --namespace devboxes \
+  "${gpu_profile[@]}" \
+  --set 'gpu.profiles[1].name=nvidia-l4' \
+  --set 'gpu.profiles[1].displayName=Duplicate NVIDIA L4' \
+  --set-string 'gpu.profiles[1].resourceName=nvidia.com/gpu' \
+  --set 'gpu.profiles[1].count=1' \
+  >"$temporary_directory/duplicate.yaml" \
+  2>"$temporary_directory/duplicate.err"; then
+  printf 'error: GPU render accepted duplicate profile names\n' >&2
+  exit 1
+fi
+grep -Fq 'duplicate name' "$temporary_directory/duplicate.err"
+
+if helm template devboxes "$chart" --namespace devboxes \
+  "${gpu_profile[@]}" \
+  --set gpu.defaultProfile=missing \
+  >"$temporary_directory/missing-profile.yaml" \
+  2>"$temporary_directory/missing-profile.err"; then
+  printf 'error: GPU render accepted a default that is not configured\n' >&2
+  exit 1
+fi
+grep -Fq 'must name an entry' "$temporary_directory/missing-profile.err"
+
+if helm template devboxes "$chart" --namespace devboxes \
+  "${gpu_profile[@]}" \
+  --set-string 'gpu.profiles[0].resourceName=nvidia..com/gpu' \
+  >"$temporary_directory/invalid-resource.yaml" \
+  2>"$temporary_directory/invalid-resource.err"; then
+  printf 'error: GPU render accepted an invalid extended resource\n' >&2
+  exit 1
+fi
+grep -Fq 'resourceName' "$temporary_directory/invalid-resource.err"
+
+if helm template devboxes "$chart" --namespace devboxes \
+  "${gpu_profile[@]}" \
+  --set-string 'gpu.profiles[0].workspaceImage=https://registry.example/devboxes-cuda:12.8' \
+  >"$temporary_directory/invalid-image.yaml" \
+  2>"$temporary_directory/invalid-image.err"; then
+  printf 'error: GPU render accepted a workspace image URL scheme\n' >&2
+  exit 1
+fi
+grep -Fq 'workspaceImage must not contain a URL scheme' \
+  "$temporary_directory/invalid-image.err"
+
+if helm template devboxes "$chart" --namespace devboxes \
+  "${gpu_profile[@]}" \
+  --set 'gpu.profiles[0].tolerations[0].value=unexpected' \
+  >"$temporary_directory/invalid-toleration.yaml" \
+  2>"$temporary_directory/invalid-toleration.err"; then
+  printf 'error: GPU render accepted an Exists toleration with a value\n' >&2
+  exit 1
+fi
+grep -Fq 'tolerations' "$temporary_directory/invalid-toleration.err"
+
+printf 'Verified disabled, enabled, and invalid GPU Helm contracts.\n'

--- a/workspace/entrypoint.sh
+++ b/workspace/entrypoint.sh
@@ -23,10 +23,52 @@ read_secret() {
   fi
 }
 
+configure_gpu_groups() {
+  local raw_groups="${DEVBOX_GPU_SUPPLEMENTAL_GROUPS:-}"
+  local group_id group_entry group_name
+  local -a group_ids=()
+  local -A seen_group_ids=()
+
+  [[ -n "$raw_groups" ]] || return 0
+  IFS=',' read -r -a group_ids <<< "$raw_groups"
+  if (( ${#group_ids[@]} > 8 )); then
+    log "DEVBOX_GPU_SUPPLEMENTAL_GROUPS contains more than eight group IDs"
+    return 1
+  fi
+
+  for group_id in "${group_ids[@]}"; do
+    if [[ ! "$group_id" =~ ^[1-9][0-9]{0,9}$ ]] \
+      || (( group_id > 2147483647 )); then
+      log "DEVBOX_GPU_SUPPLEMENTAL_GROUPS contains an invalid group ID"
+      return 1
+    fi
+    if [[ -n "${seen_group_ids[$group_id]+configured}" ]]; then
+      log "DEVBOX_GPU_SUPPLEMENTAL_GROUPS contains a duplicate group ID"
+      return 1
+    fi
+    seen_group_ids[$group_id]=1
+
+    group_entry="$(getent group "$group_id" || true)"
+    if [[ -n "$group_entry" ]]; then
+      group_name="${group_entry%%:*}"
+    else
+      group_name="devbox-device-$group_id"
+      if getent group "$group_name" >/dev/null; then
+        log "cannot create supplemental group $group_id because $group_name already exists"
+        return 1
+      fi
+      groupadd --gid "$group_id" "$group_name"
+    fi
+    usermod --append --groups "$group_name" dev
+  done
+}
+
 if [[ ! -s "$AUTHORIZED_KEYS" ]]; then
   log "SSH_AUTHORIZED_KEYS is missing or empty; refusing to start an inaccessible box"
   exit 1
 fi
+
+configure_gpu_groups
 
 printf '%s\n' "${DEVBOX_NAME:-devbox}" > /run/devbox-name
 chmod 0644 /run/devbox-name

--- a/workspace/tests/test-image-terminal.sh
+++ b/workspace/tests/test-image-terminal.sh
@@ -3,7 +3,13 @@ set -Eeuo pipefail
 
 image="${1:-devboxes-workspace:local}"
 container="devboxes-terminal-test-$RANDOM"
-trap 'docker rm -f "$container" >/dev/null 2>&1 || true' EXIT INT TERM
+group_container="devboxes-gpu-group-test-$RANDOM"
+temporary_directory="$(mktemp -d)"
+cleanup() {
+  docker rm -f "$container" "$group_container" >/dev/null 2>&1 || true
+  rm -rf "$temporary_directory"
+}
+trap cleanup EXIT INT TERM
 
 docker run -d --name "$container" --entrypoint /bin/bash "$image" -lc \
   'mkdir -p /home/dev/workspace && chown -R dev:dev /home/dev && exec sleep infinity' >/dev/null
@@ -40,4 +46,21 @@ if [[ "$unknown_output" == *'missing or unsuitable terminal'* ]]; then
   exit 1
 fi
 
-printf 'Verified xterm-ghostty and unknown TERM keep tmux alive in %s.\n' "$image"
+ssh-keygen -q -t ed25519 -N '' -f "$temporary_directory/id_ed25519"
+docker run -d --name "$group_container" \
+  --group-add 4242 \
+  --group-add 4343 \
+  --env DEVBOX_GPU_SUPPLEMENTAL_GROUPS=4242,4343 \
+  --volume "$temporary_directory/id_ed25519.pub:/run/devbox-secrets/SSH_AUTHORIZED_KEYS:ro" \
+  "$image" >/dev/null
+for _ in {1..20}; do
+  if docker exec "$group_container" runuser -u dev -- id -G >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.25
+done
+dev_groups="$(docker exec "$group_container" runuser -u dev -- id -G)"
+grep -Eq '(^| )4242( |$)' <<< "$dev_groups"
+grep -Eq '(^| )4343( |$)' <<< "$dev_groups"
+
+printf 'Verified terminal handling and GPU device groups in %s.\n' "$image"


### PR DESCRIPTION
## Summary

- add opt-in, operator-owned GPU profiles with strict Helm schema and controller validation
- expose the same safe profile catalog through the authenticated API, `devbox gpu profiles`, `devbox create --gpu` / `--gpu-profile`, and the responsive dashboard
- map each profile to an exact extended resource and count, with optional workspace image, RuntimeClass, supplemental groups, node selector, and tolerations
- pin the resolved creation-time profile on each Deployment so stop, start, TTL expiry, profile retirement, and Insights reconciliation cannot silently change the workload contract
- surface Kubernetes scheduling reasons in API, CLI timeout, and dashboard state
- harden non-root device access by materializing approved group IDs for the OpenSSH `dev` session while keeping the Insights privacy sidecar on the release image
- document prerequisites, NVIDIA and AMD examples, dedicated / partitioned / shared semantics, DRA bridge compatibility, images, lifecycle, security, operations, support, and troubleshooting

## Design

Users can select only a stable profile name. Images, resource names, counts, RuntimeClasses, groups, selectors, tolerations, privileged mode, host paths, and device paths remain operator policy. CPU-only stays the initial and default path.

Profiles use vendor-qualified Kubernetes extended resources, so they work with established device plugins and with DRA deployments that expose a compatible extended-resource bridge. Devboxes intentionally does not install cluster-wide drivers, runtimes, plugins, RuntimeClasses, or labels.

## Validation

- `make lint`
- `make test`: 144 controller tests at 88.67% coverage and 22 CLI tests
- `make helm`: disabled, enabled, and invalid GPU chart contracts
- `make images`: both images plus terminal and real image-level device-group checks
- full disposable Kind lifecycle: capability discovery, CLI GPU creation, exact pod contract, Pending scheduler diagnostics, GPU cleanup, Insights, SSH, persistence, restart, retain, reuse, and purge
- dashboard and in-product docs QA at desktop, tablet, and mobile widths, including real create flow and a clean browser console

## Hardware boundary

The clean-cluster test intentionally requests an unavailable extended resource to prove the portable contract and failure path. Physical-device validation remains vendor- and cluster-specific; the operator guide defines the required driver, runtime, image, diagnostic, stop/start, and per-profile acceptance checks.

Closes #18

## Release

- synchronizes the chart, controller, CLI, lockfiles, installer, static assets, install examples, project status, Artifact Hub metadata, and changelog at `v0.4.0`
- keeps the release tag gated on the protected, squash-merged commit and the repository's immutable `v*` tag ruleset
- revalidates the release metadata locally with the full lint, test, and Helm suite before remote CI
