### PR TITLE
release: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Devboxes are documented here. The project follows [Keep a
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-23
+
 ### Added
 
 - Added opt-in custom image profiles across Helm, the API, CLI, dashboard, authenticated documentation, and public documentation. Profiles support isolated pod-local service sidecars and explicitly vetted Devboxes-compatible workspace derivatives.
@@ -12,6 +14,10 @@ All notable changes to Devboxes are documented here. The project follows [Keep a
 ### Changed
 
 - Persist the fully resolved custom image profile on each workspace so stop, start, TTL expiry, and Insights template reconciliation cannot silently change an existing image contract after Helm configuration changes.
+
+### Fixed
+
+- Serialize each workspace lifecycle with Insights reconciliation so a deleted workspace cannot have its scoped credential Secret recreated from a stale reconciliation snapshot.
 
 ### Security
 
@@ -124,7 +130,8 @@ All notable changes to Devboxes are documented here. The project follows [Keep a
 - Portable Helm chart with values schema, namespace-scoped RBAC, configurable storage, ingress, LoadBalancer or NodePort SSH, ServiceMonitor, and disruption budget.
 - macOS and Linux CLI releases, SHA-256 verification installer, GHCR images, OCI chart publishing, image provenance attestations, and clean Kind install CI.
 
-[Unreleased]: https://github.com/vicotrbb/devboxes/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/vicotrbb/devboxes/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/vicotrbb/devboxes/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/vicotrbb/devboxes/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/vicotrbb/devboxes/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/vicotrbb/devboxes/compare/v0.2.0...v0.2.1

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ kubectl -n devboxes create secret generic devboxes-workspace \
   --from-file=SSH_AUTHORIZED_KEYS="$HOME/.ssh/id_ed25519.pub"
 
 helm install devboxes oci://ghcr.io/vicotrbb/charts/devboxes \
-  --version 0.4.0 \
+  --version 0.5.0 \
   --namespace devboxes
 ```
 
@@ -351,7 +351,7 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md) before proposing a change. Security repo
 
 ## Project status
 
-Devboxes is at `v0.4`: useful and installable, with an intentionally narrow trust model. Compatibility follows semantic versioning after `v1.0`; before then, minor releases may include documented configuration or API changes. PVC data is never automatically deleted, including at TTL expiry.
+Devboxes is at `v0.5`: useful and installable, with an intentionally narrow trust model. Compatibility follows semantic versioning after `v1.0`; before then, minor releases may include documented configuration or API changes. PVC data is never automatically deleted, including at TTL expiry.
 
 ## License
 

--- a/charts/devboxes/Chart.yaml
+++ b/charts/devboxes/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: devboxes
 description: Self-hosted, ephemeral development environments on Kubernetes
 type: application
-version: 0.4.0
-appVersion: "0.4.0"
+version: 0.5.0
+appVersion: "0.5.0"
 kubeVersion: ">=1.29.0-0"
 home: https://github.com/vicotrbb/devboxes
 icon: https://raw.githubusercontent.com/vicotrbb/devboxes/main/docs/assets/devboxes-mark.svg
@@ -17,8 +17,10 @@ annotations:
   artifacthub.io/category: integration-delivery
   artifacthub.io/changes: |
     - kind: added
-      description: Add operator-approved GPU profiles across Helm, API, CLI, and dashboard workflows
+      description: Add operator-approved custom image profiles across Helm, API, CLI, and dashboard workflows
     - kind: added
-      description: Add accelerator discovery, allocation reporting, and scheduler diagnostics
+      description: Add approved image discovery, lifecycle pinning, and hardened service sidecars
+    - kind: fixed
+      description: Serialize Insights reconciliation with workspace lifecycle deletion
     - kind: security
-      description: Restrict users to named operator-owned hardware profiles and pinned workload contracts
+      description: Restrict users to named operator-owned image profiles and pinned workload contracts

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "devbox-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devbox-cli"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.96"
 description = "Terminal client for self-hosted Kubernetes development environments"

--- a/controller/pyproject.toml
+++ b/controller/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "devboxes-controller"
-version = "0.4.0"
+version = "0.5.0"
 description = "Controller and dashboard for self-hosted Kubernetes development environments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/controller/src/devboxes_controller/__init__.py
+++ b/controller/src/devboxes_controller/__init__.py
@@ -1,3 +1,3 @@
 """Devboxes controller package."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/controller/src/devboxes_controller/templates/cli_authorize.html
+++ b/controller/src/devboxes_controller/templates/cli_authorize.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="color-scheme" content="light">
     <title>Authorize Devbox CLI · Devboxes</title>
-    <link rel="icon" href="/static/favicon.svg?v=0.4.0" type="image/svg+xml">
-    <link rel="stylesheet" href="/static/styles.css?v=0.4.0">
+    <link rel="icon" href="/static/favicon.svg?v=0.5.0" type="image/svg+xml">
+    <link rel="stylesheet" href="/static/styles.css?v=0.5.0">
   </head>
   <body class="login-page">
     <main class="authorization-shell" aria-labelledby="authorization-title">

--- a/controller/src/devboxes_controller/templates/login.html
+++ b/controller/src/devboxes_controller/templates/login.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="color-scheme" content="light">
     <title>Sign in · Devboxes</title>
-    <link rel="icon" href="/static/favicon.svg?v=0.4.0" type="image/svg+xml">
-    <link rel="stylesheet" href="/static/styles.css?v=0.4.0">
+    <link rel="icon" href="/static/favicon.svg?v=0.5.0" type="image/svg+xml">
+    <link rel="stylesheet" href="/static/styles.css?v=0.5.0">
   </head>
   <body class="login-page">
     <main class="login-shell">

--- a/controller/tests/test_app.py
+++ b/controller/tests/test_app.py
@@ -79,7 +79,7 @@ def test_browser_login_and_dashboard_session() -> None:
         assert dashboard.headers["x-content-type-options"] == "nosniff"
         assert "Kubernetes connected" in dashboard.text
         assert "cluster default storage" in dashboard.text
-        styles = client.get("/static/styles.css?v=0.4.0")
+        styles = client.get("/static/styles.css?v=0.5.0")
         assert "[hidden]" in styles.text
         assert "display: none !important" in styles.text
         payload = client.get("/api/v1/devboxes").json()

--- a/controller/uv.lock
+++ b/controller/uv.lock
@@ -382,7 +382,7 @@ wheels = [
 
 [[package]]
 name = "devboxes-controller"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,9 +3,9 @@
 Use a values file for durable installations:
 
 ```bash
-helm show values oci://ghcr.io/vicotrbb/charts/devboxes --version 0.4.0 > values.yaml
+helm show values oci://ghcr.io/vicotrbb/charts/devboxes --version 0.5.0 > values.yaml
 helm upgrade --install devboxes oci://ghcr.io/vicotrbb/charts/devboxes \
-  --version 0.4.0 \
+  --version 0.5.0 \
   --namespace devboxes \
   --create-namespace \
   --values values.yaml

--- a/docs/golden-path.md
+++ b/docs/golden-path.md
@@ -47,7 +47,7 @@ kubectl create namespace devboxes
 # Create devboxes-auth and devboxes-workspace here, as described below.
 
 helm upgrade --install devboxes oci://ghcr.io/vicotrbb/charts/devboxes \
-  --version 0.4.0 \
+  --version 0.5.0 \
   --namespace devboxes \
   --values values.yaml
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "devboxes-repository-tooling",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "devboxes-repository-tooling",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "devDependencies": {
         "@eslint/js": "10.0.1",
         "eslint": "10.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devboxes-repository-tooling",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "description": "JavaScript and documentation quality gates for Devboxes",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@ set -eu
 
 release="${DEVBOXES_RELEASE:-devboxes}"
 namespace="${DEVBOXES_NAMESPACE:-devboxes}"
-version="${DEVBOXES_VERSION:-0.4.0}"
+version="${DEVBOXES_VERSION:-0.5.0}"
 repository="${DEVBOXES_CHART_REPOSITORY:-oci://ghcr.io/vicotrbb/charts/devboxes}"
 chart_source="${DEVBOXES_CHART_SOURCE:-auto}"
 controller_secret="${DEVBOXES_CONTROLLER_SECRET:-devboxes-auth}"


### PR DESCRIPTION
## Release

Prepare Devboxes `v0.5.0` after PR #35.

- synchronize chart, CLI, controller, installer, cache-busting assets, lockfiles, and documentation
- publish the operator-approved custom image catalog feature and its hardened lifecycle behavior
- record the Insights reconciliation deletion-race fix

## Validation

- `make lint`
- `make test` (157 controller tests; 25 CLI tests)
- `make helm`
- `scripts/check-version.sh`
- full Kind lifecycle E2E for the feature and race fix

The release tag will be created only after this PR and the post-merge main CI are green.